### PR TITLE
Fix/json_passing

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -1,5 +1,5 @@
 import { SQLJob } from "./sqlJob";
-import { QueryOptions, QueryResult } from "./types";
+import { QueryOptions, QueryResult, ServerResponse } from "./types";
 
 /**
  * Represents the possible states of a query execution.
@@ -197,8 +197,7 @@ export class Query<T> {
       };
     }
     this.rowsToFetch = rowsToFetch;
-    let result = await this.job.send(JSON.stringify(queryObject));
-    let queryResult: QueryResult<T> = JSON.parse(result);
+    let queryResult = await this.job.send<QueryResult<T>>(queryObject);
 
     this.state = queryResult.is_done
       ? QueryState.RUN_DONE
@@ -248,9 +247,8 @@ export class Query<T> {
     };
 
     this.rowsToFetch = rowsToFetch;
-    let result = await this.job.send(JSON.stringify(queryObject));
+    let queryResult = await this.job.send<QueryResult<T>>(queryObject);
 
-    let queryResult: QueryResult<T> = JSON.parse(result);
     this.state = queryResult.is_done
       ? QueryState.RUN_DONE
       : QueryState.RUN_MORE_DATA_AVAILABLE;
@@ -278,7 +276,7 @@ export class Query<T> {
         type: `sqlclose`,
       };
 
-      return this.job.send(JSON.stringify(queryObject));
+      return this.job.send<ServerResponse>(queryObject);
     } else if (undefined === this.correlationId) {
       this.state = QueryState.RUN_DONE;
     }

--- a/src/sqlJob.ts
+++ b/src/sqlJob.ts
@@ -270,10 +270,10 @@ export class SQLJob {
    * @param type - The type of explain to perform (default is ExplainType.Run).
    * @returns A promise that resolves to the explain results.
    */
-  async explain(
+  async explain<T>(
     statement: string,
     type: ExplainType = ExplainType.Run
-  ): Promise<ExplainResults<any>> {
+  ): Promise<ExplainResults<T>> {
     const explainRequest = {
       id: SQLJob.getNewUniqueId(),
       type: `dove`,
@@ -281,7 +281,7 @@ export class SQLJob {
       run: type === ExplainType.Run,
     };
 
-    const explainResult = await this.send<ExplainResults<any>>(explainRequest);
+    const explainResult = await this.send<ExplainResults<T>>(explainRequest);
 
     if (explainResult.success !== true) {
       throw new Error(explainResult.error || `Failed to explain.`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,7 @@ export interface ServerResponse {
 
 export interface ServerRequest {
   id: string;
+  type: string;
 }
 
 /** Interface representing the result of a connection request. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,10 @@ export interface ServerResponse {
   sql_state: string;
 }
 
+export interface ServerRequest {
+  id: string;
+}
+
 /** Interface representing the result of a connection request. */
 export interface ConnectionResult extends ServerResponse {
   /** Unique job identifier for the connection. */

--- a/test/pool.test.ts
+++ b/test/pool.test.ts
@@ -82,6 +82,8 @@ test("Starting size of 0", async () => {
 
 test("Performance test", async () => {
   let pool = new Pool({ creds, maxSize: 5, startingSize: 5 });
+
+  // Pool 1
   await pool.init();
   const startPool1 = Date.now();
   let queries = [];
@@ -90,9 +92,11 @@ test("Performance test", async () => {
   }
   let results: QueryResult<any>[] = await Promise.all(queries);
   const endPool1 = Date.now();
-  await pool.end();
+  pool.end();
+
   results.forEach((res) => expect(res.has_results).toBe(true));
 
+  // Pool 2
   pool = new Pool({ creds, maxSize: 1, startingSize: 1 });
   await pool.init();
   const startPool2 = Date.now();
@@ -101,22 +105,20 @@ test("Performance test", async () => {
     queries.push(pool.execute("select * FROM SAMPLE.SYSCOLUMNS"));
   }
   results = await Promise.all(queries);
+
   const endPool2 = Date.now();
 
-  await pool.end();
+  pool.end();
   results.forEach((res) => expect(res.has_results).toBe(true));
 
-  const noPoolStart = Date.now();
-  for (let i = 0; i < 20; i++) {
-    const job = new SQLJob();
-    await job.connect(creds);
-    await job.execute("select * FROM SAMPLE.SYSCOLUMNS");
-    await job.close();
-  }
-  const noPoolEnd = Date.now();
+  // Compare
+  const multiJobPoolTime = endPool1 - startPool1;
+  const singleJobPoolTime = endPool2 - startPool2;
 
-  expect(endPool2 - startPool2).toBeGreaterThan(endPool1 - startPool1);
-  expect(noPoolEnd - noPoolStart).toBeGreaterThan(endPool2 - startPool2);
+  console.log({ multiJobPoolTime, singleJobPoolTime });
+
+  // Expect singlejob to be slower than multi job
+  expect(singleJobPoolTime).toBeGreaterThan(multiJobPoolTime);
 }, 30000);
 
 test("Pop jobs returns free job", async () => {

--- a/test/pool.test.ts
+++ b/test/pool.test.ts
@@ -115,8 +115,6 @@ test("Performance test", async () => {
   const multiJobPoolTime = endPool1 - startPool1;
   const singleJobPoolTime = endPool2 - startPool2;
 
-  console.log({ multiJobPoolTime, singleJobPoolTime });
-
   // Expect singlejob to be slower than multi job
   expect(singleJobPoolTime).toBeGreaterThan(multiJobPoolTime);
 }, 30000);

--- a/test/sql.test.ts
+++ b/test/sql.test.ts
@@ -315,8 +315,8 @@ test("Prepare SQL with Edge Case Inputs", async () => {
   //   error = err;
   // }
 
-  expect(error).toBeDefined();
-  expect(error.message).toEqual("Not a JSON Array: 99");
+  // expect(error).toBeDefined();
+  // expect(error.message).toEqual("Not a JSON Array: 99");
 
   try {
     query = await job.query<any>(


### PR DESCRIPTION
* Simplifies the `SQLJob#send` logic by allowing a JSON object to be passed in
* Fix pool performance test incorrectly testing single job performance
* Fix broken 'Prepare SQL with Edge Case Inputs' test, which was testing a variable changed by lines of code commented out