### PR TITLE
Implement sql tagged function and test case

### DIFF
--- a/src/pool.ts
+++ b/src/pool.ts
@@ -1,5 +1,5 @@
 import { SQLJob } from "./sqlJob";
-import { DaemonServer, JDBCOptions, JobStatus, QueryOptions } from "./types";
+import { BindingValue, DaemonServer, JDBCOptions, JobStatus, QueryOptions } from "./types";
 
 /**
  * Represents the options for configuring a connection pool.
@@ -241,6 +241,14 @@ export class Pool {
   execute<T>(sql: string, opts?: QueryOptions) {
     const job = this.getJob();
     return job.execute<T>(sql, opts);
+  }
+
+  sql<T>(statementParts: TemplateStringsArray, ...parameters: BindingValue[]) {
+    const job = this.getJob();
+
+    const statement = statementParts.join(`?`);
+
+    return job.execute<T>(statement, {parameters});
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -129,6 +129,8 @@ export enum ServerTraceDest {
   IN_MEM = "IN_MEM"
 }
 
+export type BindingValue = string | number;
+
 /** Interface representing options for query execution. */
 export interface QueryOptions {
   /** Whether to return terse results. */
@@ -138,7 +140,7 @@ export interface QueryOptions {
   isClCommand?: boolean;
   
   /** Parameters for the query. */
-  parameters?: any[];
+  parameters?: BindingValue[];
 }
 
 /** Interface representing the result of a configuration set request. */

--- a/test/pool.test.ts
+++ b/test/pool.test.ts
@@ -59,6 +59,23 @@ test(`Simple pool (using pool#execute)`, async () => {
   await pool.end();
 });
 
+test(`Pool tagged function`, async () => {
+  const pool = new Pool({ creds, maxSize: 1, startingSize: 1 });
+  
+  await pool.init();
+
+  const baseSalary = 1000;
+
+  const result = await pool.sql`
+    select * from sample.employee where salary > ${baseSalary}
+  `;
+
+  expect(result.has_results).toBe(true);
+  expect(result.data.length).toBeGreaterThan(0);
+
+  await pool.end();
+});
+
 test("Starting size greater than max size", async () => {
   const pool = new Pool({ creds, maxSize: 1, startingSize: 10 });
   await expect(() => pool.init()).rejects.toThrowError(


### PR DESCRIPTION
Implements the `sql` tagged function, as seen in Vercel's postgres library.

Allows the user to write an SQL and make use of template literals to secure the provided statement. It's super cool.

Test case provided.

It even highlights in VS Code!

![image](https://github.com/user-attachments/assets/6ca16cae-edb0-45db-9456-31e122ec2535)
