### PR TITLE
Fixed usage of `ignoreUnauthorized`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "mapepire-js",
+  "name": "@ibm/mapepire-js",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mapepire-js",
+      "name": "@ibm/mapepire-js",
       "version": "0.0.1",
+      "license": "Apache-2.0",
       "dependencies": {
         "ws": "^8.16.0"
       },

--- a/src/sqlJob.ts
+++ b/src/sqlJob.ts
@@ -1,25 +1,22 @@
+import { EventEmitter } from "stream";
+import WebSocket from "ws";
+import { Query } from "./query";
 import {
-  JDBCOptions,
   ConnectionResult,
-  Rows,
-  QueryResult,
-  JobLogEntry,
-  CLCommandResult,
-  VersionCheckResult,
+  DaemonServer,
+  ExplainResults,
+  ExplainType,
   GetTraceDataResult,
+  JDBCOptions,
+  JobLogEntry,
+  JobStatus,
+  QueryOptions,
   ServerTraceDest,
   ServerTraceLevel,
   SetConfigResult,
-  QueryOptions,
-  ExplainResults,
-  DaemonServer,
-  ExplainType,
-  JobStatus,
   TransactionEndType,
+  VersionCheckResult
 } from "./types";
-import { Query } from "./query";
-import { EventEmitter } from "stream";
-import WebSocket from "ws";
 
 interface ReqRespFmt {
   id: string;
@@ -97,7 +94,7 @@ export class SQLJob {
           },
           ca: db2Server.ca,
           timeout: 5000,
-          rejectUnauthorized: db2Server.ca ? false : true, //This allows a self-signed certificate to be used
+          rejectUnauthorized: db2Server.ca ? false : !db2Server.ignoreUnauthorized, //This allows a self-signed certificate to be used
         }
       );
 

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -1,15 +1,15 @@
 import { beforeAll, expect, test } from 'vitest';
-import { DaemonServer } from '../src/types';
 import { SQLJob } from '../src';
 import { getCertificate } from '../src/tls';
+import { DaemonServer } from '../src/types';
 import { ENV_CREDS } from './env';
 
-let creds: DaemonServer = {...ENV_CREDS};
+let creds: DaemonServer = { ...ENV_CREDS };
 let invalidCreds: DaemonServer = {
-    ...ENV_CREDS,
-    user: "fakeuser",
-    password: "fakepassword",
-  };
+  ...ENV_CREDS,
+  user: "fakeuser",
+  password: "fakepassword",
+};
 
 beforeAll(async () => {
   const ca = await getCertificate(creds);
@@ -26,28 +26,46 @@ test(`Connect to database`, async () => {
 });
 
 test('Connect to Database with Invalid Properties', async () => {
-    const job = new SQLJob();
-    try {
-      await job.connect(invalidCreds);
-    } catch (error) {
-      expect(error.message).toContain('The application server rejected the connection. (User ID is not known.:FAKEUSER)');
-    }
-  });
+  const job = new SQLJob();
+  try {
+    await job.connect(invalidCreds);
+  } catch (error) {
+    expect(error.message).toContain('The application server rejected the connection. (User ID is not known.:FAKEUSER)');
+  }
+});
 
 test('Implicit Disconnection on New Connect Request', async () => {
+  const job = new SQLJob();
+
+  // First connection
+  const firstRes = await job.connect(creds);
+  const firstJobId = firstRes.job;
+  expect(firstJobId).toContain('QZDASOINIT');
+
+  // Second connection
+  const secondRes = await job.connect(creds);
+  const secondJobId = secondRes.job;
+  expect(secondJobId).toContain('QZDASOINIT');
+  await job.close();
+
+  // Ensure job IDs are different
+  expect(firstJobId).not.toBe(secondJobId);
+});
+
+test('Allow empty CA and self-signed certificate', async () => {
+  const noCACreds: DaemonServer = { ...ENV_CREDS, ca: undefined, ignoreUnauthorized: false };
+  
+  //Connection refused because CA is empty and ignoreUnauthorized is false
+  try {
     const job = new SQLJob();
+    await job.connect(noCACreds);
+  } catch (error) {
+    expect(error.message).toContain('self-signed certificate');
+  }
 
-    // First connection
-    const firstRes = await job.connect(creds);
-    const firstJobId = firstRes.job;
-    expect(firstJobId).toContain('QZDASOINIT');
-
-    // Second connection
-    const secondRes = await job.connect(creds);
-    const secondJobId = secondRes.job;
-    expect(secondJobId).toContain('QZDASOINIT');
-    await job.close();
-
-    // Ensure job IDs are different
-    expect(firstJobId).not.toBe(secondJobId);
+  //Connection OK because ignoreUnauthorized is true
+  noCACreds.ignoreUnauthorized = true;
+  const job = new SQLJob();
+  await job.connect(noCACreds);
+  await job.close();
 });


### PR DESCRIPTION
The nodeJS SQK documentation [states that the `ignoreUnauthorized` field](https://mapepire-ibmi.github.io/guides/usage/nodejs/#allow-all-certificates) can be set to `true` to allow all certificates when connecting to the mapepire server.

That field was not actually used when connecting, requiring the credentials' `ca` field to be loaded.

This PR fixes the connection process to actually take `ignoreUnauthorized` into account.

A test case has been added to check this capability.