### PR TITLE
Make re-usable fields protected

### DIFF
--- a/src/sqlJob.ts
+++ b/src/sqlJob.ts
@@ -41,17 +41,17 @@ export class SQLJob {
   /**
    * A counter to generate unique IDs for each SQLJob instance.
    */
-  private static uniqueIdCounter: number = 0;
+  protected static uniqueIdCounter: number = 0;
   private socket: WebSocket;
-  private responseEmitter: EventEmitter = new EventEmitter();
-  private status: JobStatus = JobStatus.NotStarted;
+  protected responseEmitter: EventEmitter = new EventEmitter();
+  protected status: JobStatus = JobStatus.NotStarted;
 
-  private traceFile: string | undefined;
-  private isTracingChannelData: boolean = false;
+  protected traceFile: string | undefined;
+  protected isTracingChannelData: boolean = false;
 
   //currently unused but we will inevitably need a unique ID assigned to each instance
   // since server job names can be reused in some circumstances
-  private uniqueId = SQLJob.getNewUniqueId(`sqljob`);
+  protected uniqueId = SQLJob.getNewUniqueId(`sqljob`);
 
   id: string | undefined;
 


### PR DESCRIPTION
So the `SQLJob` class can be correctly re-implemented using other connection methods (like SSH, via vscode-db2i), we need to make some of the fields re-usable in subclasses which extend `SQLJob`.