### PR TITLE
Add new API to get the query's job

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -283,6 +283,13 @@ export class Query<T> {
   }
 
   /**
+   * Retrieves the SQL job that the query is running under.
+   */
+  public getHostJob(): SQLJob {
+    return this.job;
+  }
+
+  /**
    * Retrieves the correlation ID of the query.
    *
    * @returns The correlation ID as a string.

--- a/test/sql.test.ts
+++ b/test/sql.test.ts
@@ -22,6 +22,10 @@ test("Simple SQL query", async () => {
   await job.connect(creds);
   const query = await job.query<any>("select * from sample.department");
   const res = await query.execute();
+
+  const queryJob = query.getHostJob();
+  expect(queryJob.id).toBe(job.id);
+  
   await query.close();
   await job.close();
   expect(res.data.length).toBeGreaterThanOrEqual(13);


### PR DESCRIPTION
This pull request adds a new API to the Query class that allows retrieving the SQL job that the query is running under. It also includes a test case for the new query API.