### PR TITLE
Use and export enums correctly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,3 @@ export { SQLJob } from "./sqlJob";
 export { Pool } from "./pool";
 export { getCertificate } from "./tls";
 export * as States from "./states";
-export * as Types from "./types";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { SQLJob } from "./sqlJob";
 export { Pool } from "./pool";
 export { getCertificate } from "./tls";
-
+export * as States from "./states";
 export * as Types from "./types";

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -1,5 +1,6 @@
 import { SQLJob } from "./sqlJob";
-import { BindingValue, DaemonServer, JDBCOptions, JobStatus, QueryOptions } from "./types";
+import { BindingValue, DaemonServer, JDBCOptions, QueryOptions } from "./types";
+import {JobStatus} from "./states";
 
 /**
  * Represents the options for configuring a connection pool.
@@ -35,7 +36,7 @@ interface PoolAddOptions {
   poolIgnore?: boolean
 }
 
-const INVALID_STATES: JobStatus[] = ["ended", "notStarted"];
+const INVALID_STATES: JobStatus[] = [JobStatus.ENDED, JobStatus.NOT_STARTED];
 
 /**
  * Represents a connection pool for managing SQL jobs.

--- a/src/sqlJob.ts
+++ b/src/sqlJob.ts
@@ -267,7 +267,7 @@ export class SQLJob {
    */
   async explain<T>(
     statement: string,
-    type: ExplainType = ExplainType.Run
+    type: ExplainType = ExplainType.RUN
   ): Promise<ExplainResults<T>> {
     const explainRequest = {
       id: SQLJob.getNewUniqueId(),

--- a/src/states.ts
+++ b/src/states.ts
@@ -8,8 +8,8 @@ export enum JobStatus {
 }
 
 export enum ExplainType {
-  Run = "run",
-  DoNotRun = "doNotRun",
+  RUN = "run",
+  DO_NOT_RUN = "doNotRun",
 }
 
 export enum TransactionEndType {

--- a/src/states.ts
+++ b/src/states.ts
@@ -1,0 +1,18 @@
+
+export enum JobStatus {
+  NOT_STARTED = "notStarted",
+  CONNECTING = "connecting",
+  READY = "ready",
+  BUSY = "busy",
+  ENDED = "ended",
+}
+
+export enum ExplainType {
+  Run = "run",
+  DoNotRun = "doNotRun",
+}
+
+export enum TransactionEndType {
+  COMMIT = "COMMIT",
+  ROLLBACK = "ROLLBACK",
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,15 +21,6 @@ export interface DaemonServer {
   ca?: string | Buffer;
 }
 
-/** Type representing the possible statuses of a job. */
-export type JobStatus = "notStarted" | "connecting" | "ready" | "busy" | "ended";
-
-/** Type representing the types of explain requests. */
-export type ExplainType = "run" | "doNotRun";
-
-/** Type representing the types of transaction endings. */
-export type TransactionEndType = "commit" | "rollback";
-
 /** Interface representing a standard server response. */
 export interface ServerResponse {
   /** Unique identifier for the request. */


### PR DESCRIPTION
I previously removed enums because we were not exporting them correctly for the library to be imported.

This time, I've moved the enums into their own files and am exporting that file individually and they generate compiled code.

Also, I removed the `Types` export since there is no runtime code (since it is only `interface`s and `type`s). Consumers of our API import like so:

```
import { SQLJob, States } from "@ibm/mapepire-js";
import { ConnectionResult, QueryResult, ServerRequest, ServerResponse } from "@ibm/mapepire-js/dist/src/types";
```