### PR TITLE
Allow optionally disabling SSL cert. verification via .env file when running tests

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,5 +4,8 @@
 # defaults to 8076
 #VITE_PORT=8076
 
+# Use this to enable non-secure communications for testing.
+#VITE_REJECT_UNAUTHORIZED=0
+
 VITE_DB_USER=X
 VITE_DB_PASS=X

--- a/test/env.ts
+++ b/test/env.ts
@@ -8,5 +8,6 @@ export const ENV_CREDS: DaemonServer = {
   host: process.env.VITE_SERVER || `localhost`,
   port: Number(process.env.VITE_PORT) || 8076,
   user: process.env.VITE_DB_USER,
-  password: process.env.VITE_DB_PASS
+  password: process.env.VITE_DB_PASS,
+  rejectUnauthorized: process.env.VITE_REJECT_UNAUTHORIZED !== "0",
 }

--- a/test/tls.test.ts
+++ b/test/tls.test.ts
@@ -6,6 +6,7 @@ import { SQLJob } from '../src';
 
 
 let creds: DaemonServer = {...ENV_CREDS};
+creds.rejectUnauthorized = true;
 
 test(`Can get cert correctly`, async () => {
   const cert = await getRootCertificate(creds);


### PR DESCRIPTION
This is just a minor ease-of-use tweak for running tests. It allows a developer to optionally disable SSL cert. verification when running tests, using a value in the .env file.

This allows one to get started quickly/easily without having to change the default dev server cert. setup or modify any tracked files in the client repo.

`rejectUnauthorized` is forced on in the TLS test suite, so those still perform as originally intended, regardless of this setting. 