### PR TITLE
Added execution time to ServerResponse

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,9 @@ export interface ServerResponse {
   
   /** SQL state code. */
   sql_state: string;
+
+  /** Execution time in millis. */
+  execution_time: number;
 }
 
 export interface ServerRequest {


### PR DESCRIPTION
Execution time in millis in ServerResponse (mapepire-server >= 2.1.8)