### PR TITLE
Export Types in index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export { SQLJob } from "./sqlJob";
 export { Pool } from "./pool";
 export { getCertificate, getRootCertificate } from "./tls";
 export * as States from "./states";
+export * from "./types";


### PR DESCRIPTION
I'd like to be able to make variables for function parameters & outputs. It required the import of @ibm/mapepire-js/dist/src/tyes , this makes the types directly available from @ibm/mapepire-js

This should make the import statements a bit cleaner.