### PR TITLE
Additional column metadata

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -218,6 +218,18 @@ export interface ColumnMetaData {
 
   /** Scale of the column. */
   scale: number;
+
+  /** Indicates whether the designated column is automatically numbered. */
+  autoIncrement: boolean;
+
+  /** Indicates the nullability of values in the designated column. */
+  nullable: number;
+
+  /** Indicates whether the designated column is definitely not writable. */
+  readOnly: boolean;
+
+  /** Indicates whether it is possible for a write on the designated column to succeed. */
+  writeable: boolean;
 }
 
 /** Type representing a collection of rows returned from a query. */


### PR DESCRIPTION
Additional column metadata: autoIncrement, nullable, readOnly and writeable

Depends on:
https://github.com/Mapepire-IBMi/mapepire-server/pull/122

Needed to fix:
https://github.com/codefori/vscode-db2i/issues/392