### PR TITLE
Added table Column metadata field

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -230,6 +230,9 @@ export interface ColumnMetaData {
 
   /** Indicates whether it is possible for a write on the designated column to succeed. */
   writeable: boolean;
+
+  /** The column's table name. */
+  table: string;
 }
 
 /** Type representing a collection of rows returned from a query. */


### PR DESCRIPTION
To be merged after https://github.com/Mapepire-IBMi/mapepire-server/pull/131

Adds the `table` field added in https://github.com/Mapepire-IBMi/mapepire-server/pull/131 to the column metadata.