### PR TITLE
Add support for fetching all rows

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -222,13 +222,13 @@ export class Query<T> {
   }
 
   /**
-   * Fetches more rows from the currently running query.
+   * Fetch a specific number or all rows from the currently running query.
    *
-   * @param rowsToFetch - The number of additional rows to fetch.
+   * @param options - Fetch options (either rows or allRows).
    * @returns A promise that resolves to the query result.
    */
-  public async fetchMore(
-    rowsToFetch: number = this.rowsToFetch
+  private async fetch(
+    options: { rows?: number; allRows?: boolean }
   ): Promise<QueryResult<T>> {
     switch (this.state) {
       case "NOT_YET_RUN":
@@ -241,10 +241,13 @@ export class Query<T> {
       cont_id: this.correlationId,
       type: `sqlmore`,
       sql: this.sql,
-      rows: rowsToFetch,
+      ...options,
     };
 
-    this.rowsToFetch = rowsToFetch;
+    if (options.rows !== undefined) {
+      this.rowsToFetch = options.rows;
+    }
+
     let queryResult = await this.job.send<QueryResult<T>>(queryObject);
 
     this.state = queryResult.is_done
@@ -258,6 +261,27 @@ export class Query<T> {
       );
     }
     return queryResult;
+  }
+
+  /**
+   * Fetches more rows from the currently running query.
+   *
+   * @param rowsToFetch - The number of additional rows to fetch.
+   * @returns A promise that resolves to the query result.
+   */
+  public async fetchMore(
+    rowsToFetch: number = this.rowsToFetch
+  ): Promise<QueryResult<T>> {
+    return this.fetch({ rows: rowsToFetch });
+  }
+
+  /**
+   * Fetches all remaining rows from the currently running query.
+   *
+   * @returns A promise that resolves to the query result.
+   */
+  public async fetchAll(): Promise<QueryResult<T>> {
+    return this.fetch({ allRows: true });
   }
 
   /**

--- a/test/sql.test.ts
+++ b/test/sql.test.ts
@@ -176,6 +176,38 @@ test("Fetch remaining with prepared", { timeout: 20000 }, async () => {
   expect(res.is_done).toEqual(true);
 });
 
+test("Fetch all remaining rows", { timeout: 20000 }, async () => {
+  const job = new SQLJob();
+  await job.connect(creds);
+  
+  const query = await job.query<any>(`
+    WITH NUMBERS (n) AS (
+        SELECT 1 FROM SYSIBM.SYSDUMMY1
+        UNION ALL
+        SELECT n + 1 FROM NUMBERS WHERE n < 305
+    )
+    SELECT * FROM NUMBERS
+  `);
+  
+  // Fetch first 100 rows
+  let res = await query.execute(100);
+  expect(res.data.length).toBe(100);
+  expect(res.is_done).toBe(false);
+  
+  // Fetch 50 more
+  res = await query.fetchMore(50);
+  expect(res.data.length).toBe(50);
+  expect(res.is_done).toBe(false);
+  
+  // Fetch all remaining (105)
+  res = await query.fetchAll();
+  expect(res.data.length).toBe(155);
+  expect(res.is_done).toBe(true);
+  
+  await query.close();
+  await job.close();
+});
+
 test("Prepared Statement", async () => {
   const job = new SQLJob();
   await job.connect(creds);

--- a/test/sql.test.ts
+++ b/test/sql.test.ts
@@ -199,7 +199,7 @@ test("Fetch all remaining rows", { timeout: 20000 }, async () => {
   expect(res.data.length).toBe(50);
   expect(res.is_done).toBe(false);
   
-  // Fetch all remaining (105)
+  // Fetch all remaining (155)
   res = await query.fetchAll();
   expect(res.data.length).toBe(155);
   expect(res.is_done).toBe(true);


### PR DESCRIPTION
The `sqlmore` request can now accept a `allRows` boolean parameter to retrieve all rows. This will be used by the database extension to support a `Retrieve All Rows` button similar to ACS RSS.

Associated change in the server: https://github.com/Mapepire-IBMi/mapepire-server/pull/146