### PR TITLE
Switch release workflow to use NPM OIDC

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,10 @@ on:
   release:
     types: [created]
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   release:
     name: Release and Publish
@@ -14,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [24.x]
 
     steps:
       - name: Checkout
@@ -34,5 +38,3 @@ jobs:
 
       - name: Publish Types to NPM
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Changes

Switch from `NPM_TOKEN` publishing to use NPM OIDC: https://docs.npmjs.com/trusted-publishers