### PR TITLE
Fixed typo in JDBC options

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -356,7 +356,7 @@ export interface JDBCOptions {
   "query storage limit"?: string;
   "receive buffer size"?: string;
   "send buffer size"?: string;
-  "vairiable field compression"?: boolean;
+  "variable field compression"?: boolean;
 
   // Sort Properties
   "sort"?: "hex" | "language" | "table";


### PR DESCRIPTION
Fixed a typo in the JDBC options name:

`vairiable field compression` -> `variable field compression`