### PR TITLE
fix(query): cleanup global query list on terminal states

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -150,7 +150,7 @@ export class Query<T> {
     }
 
     this.parameters.push(...parameters)
-    
+
     this.isPrepared = true;
     return this.parameters
   }
@@ -195,13 +195,27 @@ export class Query<T> {
       };
     }
     this.rowsToFetch = rowsToFetch;
-    let queryResult = await this.job.send<QueryResult<T>>(queryObject);
+    let queryResult: QueryResult<T>;
+    try {
+      queryResult = await this.job.send<QueryResult<T>>(queryObject);
+    } catch (error) {
+      this.removeFromGlobalList();
+      this.state = "ERROR";
+      throw error;
+    }
 
     this.state = queryResult.is_done
       ? "RUN_DONE"
       : "RUN_MORE_DATA_AVAILABLE";
+    // If the query is done, remove it from the global list to allow for garbage collection
+    if (this.state === "RUN_DONE") {
+      this.removeFromGlobalList();
+    }
 
     if (queryResult.success !== true && !this.isCLCommand) {
+      // Remove the query from the global list to allow for garbage collection
+      this.removeFromGlobalList();
+
       this.state = "ERROR";
 
       let errorList = [
@@ -245,13 +259,24 @@ export class Query<T> {
     };
 
     this.rowsToFetch = rowsToFetch;
-    let queryResult = await this.job.send<QueryResult<T>>(queryObject);
+    let queryResult: QueryResult<T>;
+    try {
+      queryResult = await this.job.send<QueryResult<T>>(queryObject);
+    } catch (error) {
+      this.removeFromGlobalList();
+      this.state = "ERROR";
+      throw error;
+    }
 
     this.state = queryResult.is_done
       ? "RUN_DONE"
       : "RUN_MORE_DATA_AVAILABLE";
+    if (this.state === "RUN_DONE") {
+      this.removeFromGlobalList();
+    }
 
     if (queryResult.success !== true) {
+      this.removeFromGlobalList();
       this.state = "ERROR";
       throw new Error(
         queryResult.error || `Failed to run query (unknown error)`
@@ -266,6 +291,9 @@ export class Query<T> {
    * @returns A promise that resolves when the query is closed.
    */
   public async close() {
+    // Remove the query from the global list to allow for garbage collection
+    this.removeFromGlobalList();
+
     if (this.correlationId && this.state !== "RUN_DONE") {
       this.state = "RUN_DONE";
       let queryObject = {
@@ -277,6 +305,17 @@ export class Query<T> {
       return this.job.send<ServerResponse>(queryObject);
     } else if (undefined === this.correlationId) {
       this.state = "RUN_DONE";
+    }
+  }
+
+  /**
+   * Removes the query from the global query list, allowing it to be garbage collected.
+   * This is called when the query is closed or completed.
+   */
+  private removeFromGlobalList() {
+    const index = Query.globalQueryList.indexOf(this);
+    if (index !== -1) {
+      Query.globalQueryList.splice(index, 1);
     }
   }
 

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -1,0 +1,136 @@
+import { beforeAll, expect, test } from "vitest";
+import { DaemonServer } from "../src/types";
+import { SQLJob, getRootCertificate } from "../src";
+import { Query } from "../src/query";
+import { ENV_CREDS } from "./env";
+
+let creds: DaemonServer = { ...ENV_CREDS };
+
+beforeAll(async () => {
+  creds.ca = await getRootCertificate(creds);
+});
+
+/**
+ * Reads the private static `Query.globalQueryList`.
+ *
+ * The cast to `any` is intentional: these are white-box tests that verify the
+ * internal retention behaviour of `Query`, so we deliberately reach past the
+ * `private static` access modifier to observe the raw list contents. This is
+ * required because `Query.getOpenIds()` filters to open states
+ * ("NOT_YET_RUN" / "RUN_MORE_DATA_AVAILABLE") and therefore would not reveal
+ * whether closed ("RUN_DONE") queries linger in the raw list.
+ */
+function getGlobalQueryList(): Query<any>[] {
+  return (Query as any).globalQueryList as Query<any>[];
+}
+
+const QUERY_COUNT = 50;
+
+test("close() removes the query from globalQueryList", { timeout: 60000 }, async () => {
+  // Clean slate so counts below are attributable to this test only.
+  await Query.cleanup();
+
+  const job = new SQLJob();
+  await job.connect(creds);
+
+  const startLen = getGlobalQueryList().length;
+
+  const created: Query<any>[] = [];
+  for (let i = 0; i < QUERY_COUNT; i++) {
+    const query = job.query<any>("values (1)");
+    created.push(query);
+    await query.execute();
+    await query.close();
+  }
+
+  const list = getGlobalQueryList();
+
+  // close() now self-removes each query from the global list, so the list is
+  // not permanently grown by running-and-closing queries. This prevents the
+  // unbounded leak where every query ever run (and its SQLJob + socket) was
+  // retained for the lifetime of the process.
+  expect(list.length).toBe(startLen);
+  for (const q of created) {
+    expect(list).not.toContain(q);
+    expect(q.getState()).toBe("RUN_DONE");
+  }
+
+  // getOpenIds filters to open states; after closing everything there are no
+  // open queries for this job.
+  expect(Query.getOpenIds(job).length).toBe(0);
+
+  await job.close();
+});
+
+test("cleanup() still releases any remaining completed queries", { timeout: 60000 }, async () => {
+  await Query.cleanup();
+
+  const job = new SQLJob();
+  await job.connect(creds);
+
+  for (let i = 0; i < QUERY_COUNT; i++) {
+    const query = job.query<any>("values (1)");
+    await query.execute();
+    await query.close();
+  }
+
+  await Query.cleanup();
+
+  const remaining = getGlobalQueryList();
+  expect(remaining.every((q) => q.getState() !== "RUN_DONE")).toBe(true);
+  expect(Query.getOpenIds(job).length).toBe(0);
+
+  await job.close();
+});
+
+test("closed queries no longer retain their SQLJob via the global list", async () => {
+  await Query.cleanup();
+
+  const job = new SQLJob();
+  await job.connect(creds);
+
+  const query = job.query<any>("values (1)");
+  await query.execute();
+  await query.close();
+  await job.close();
+
+  // The query is gone from the global list once closed, so it no longer keeps
+  // the (now closed) SQLJob and that job's WebSocket alive.
+  const list = getGlobalQueryList();
+  expect(list).not.toContain(query);
+
+  await Query.cleanup();
+});
+
+test("close() removes an unfinished query from globalQueryList", async () => {
+  await Query.cleanup();
+  const job = new SQLJob();
+  await job.connect(creds);
+
+  // Multi-row result, fetch only 1 → server can't know it's exhausted →
+  // is_done false → state stays RUN_MORE_DATA_AVAILABLE
+  const query = job.query<any>("select * from qsys2.systables");
+  const result = await query.execute(1);
+  expect(result.is_done).toBe(false);
+  // The query is still registered in the global list while it's open
+  expect(getGlobalQueryList()).toContain(query);
+
+  await query.close();
+  // close() self-removes the query from the global list, so it no longer retains
+  expect(getGlobalQueryList()).not.toContain(query);
+
+  await job.close();
+});
+
+test("a failed query is removed from globalQueryList", async () => {
+  await Query.cleanup();
+  const job = new SQLJob();
+  await job.connect(creds);
+
+  const query = job.query<any>("select * from qsys2.thistabledoesnotexist");
+  await expect(query.execute()).rejects.toThrow();
+  expect(query.getState()).toBe("ERROR");
+  expect(getGlobalQueryList()).not.toContain(query);
+
+  await job.close();
+});


### PR DESCRIPTION
### Problem:

Query instances register themselves in the private static globalQueryList array in their constructor (src/query.ts line 82), but nothing ever removes them:

close() sends the server-side sqlclose and updates state, but does not remove the entry from the list
The only removal path, Query.cleanup(), has no call sites anywhere in the library
Query is not exported from the package entrypoint (src/index.ts), so consuming applications cannot call cleanup() themselves

The result is that every query ever executed is strongly retained for the lifetime of the process. Because each Query holds a reference to its SQLJob (the private job field), retained queries also transitively pin their jobs and those jobs' WebSockets, closed at the network level, but never garbage-collectable.

In any long-running process (web servers, daemons), this is an unbounded memory leak proportional to total query count. We found it via a production Next.js service on AKS that was OOMKilled on a ~15-hour sawtooth cycle; heap snapshot analysis showed accumulated Query objects retaining closed SQLJob instances and their sockets (the heap contained roughly 3× more TLSSocket objects than the kernel had live sockets).

### Reproduction:
`leak.ts` in the repo root, run with `npx tsx --expose-gc leak.ts`:
```ts
import { SQLJob } from "./src/sqlJob";
import { Query } from "./src/query";

const job = new SQLJob(); // never connected — not needed for the repro

// Fat parameter payload to make retention visible quickly
// (e.g. a large batch insert). Real-world growth rate depends on
// actual query/parameter sizes; the mechanism is the same.
const fatParams = Array.from({ length: 10_000 }, (_, i) => [`row-${i}`, i, "x".repeat(50)]);

async function main() {
  for (let i = 1; i <= 50_000; i++) {
    const q = job.query("INSERT INTO fake VALUES (?, ?, ?)", { parameters: fatParams.flat() });
    await q.close();

    if (i % 5_000 === 0) {
      global.gc!(); // force GC so heapUsed reflects retained memory, not lazy collection
      const list = (Query as any).globalQueryList as Query<any>[];
      const mb = (process.memoryUsage().heapUsed / 1024 / 1024).toFixed(1);
      console.log(`queries: ${i}  | globalQueryList: ${list.length}  | heapUsed: ${mb} MB`);
    }
  }
}
main();
```
Before this fix — the repro itself dies of heap exhaustion before reaching 10,000 queries:
```
queries: 5000  | globalQueryList: 5000  | heapUsed: 1303.6 MB

<--- Last few GCs --->
[71604:0xc1f40c000]     8313 ms: Mark-Compact (reduce) 2018.6 (2118.1) -> 2008.0 (2070.5) MB ...
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

Note the GC freeing almost nothing (2018MB → 2008MB) — the memory is genuinely retained, not pending collection.

After this fix — flat through 50,000 queries:
```
queries: 5000   | globalQueryList: 0  | heapUsed: 10.1 MB
queries: 25000  | globalQueryList: 0  | heapUsed: 10.1 MB
queries: 50000  | globalQueryList: 0  | heapUsed: 10.1 MB
```

### Fix:
Queries now remove themselves from globalQueryList (via a private, idempotent removeFromGlobalList()) on every terminal path:

close() — removal happens before the sqlclose send, so it occurs even if the send fails on a dead connection
Natural completion — when execute()/fetchMore() receive is_done: true
Error responses — when the server replies success !== true. This path needs its own hook: error responses from the server omit is_done entirely (it is only written on the success path with a result set), so completion-based removal never fires for failures
send() rejection — connection failure mid-request now removes the entry and marks the query ERROR before rethrowing