### PR TITLE
fix: add null to BindingValue type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -83,7 +83,7 @@ export type ServerTraceLevel = "OFF" | "ON" | "ERRORS" | "DATASTREAM";
 /** Type representing the possible destinations for server trace data. */
 export type ServerTraceDest = "FILE" | "IN_MEM";
 
-export type BindingValue = string | number | (string|number)[];
+export type BindingValue = string | number | null | (string|number|null)[];
 
 /** Interface representing options for query execution. */
 export interface QueryOptions {


### PR DESCRIPTION
### Summary:

Adds `null` to the `BindingValue` union type, allowing null values to be used as SQL `NULL` bound parameters. Closes #74.

```ts
// Before
export type BindingValue = string | number | (string|number)[];

// After
export type BindingValue = string | number | null | (string|number|null)[];
```

Users passing `null` as a bound parameter (e.g. to insert SQL `NULL` into a nullable column) were getting TypeScript errors despite the runtime working correctly. The server already serialises JSON `null` to `stmt.setNull()` for scalar parameters.

### Files Changed:

`src/types.ts`

Expands the `BindingValue` type definition to support `null` in addition to `string` and `number`. This change applies to both the scalar type and the array element type, enabling null values to be passed as query binding parameters.

### Verified:

- `null` as a scalar parameter (`parameters: [null, 'foo']`) - compiles and reaches the DB as SQL `NULL` 
- Mixed `null` + non-null in the same query - works correctly 
- `Pool.execute` with `null` parameter - works correctly 

### Known Limitation:

`addToBatch` with `null` (needs separate server fix): `null` inside a batch row — e.g. `q.addToBatch([[null, 'foo'], [42, null]])` — now compiles cleanly with this type change, but the server throws `IllegalStateException` at runtime.

Root cause is in `PreparedExecute.java` on `mapepire-server`:

```java
// Current — wrong type constant, rejected by Db2 JDBC driver in batch context
stmt.setNull(i, Types.NULL);

// Suggested fix
stmt.setNull(i, stmt.getParameterMetaData().getParameterType(i));
```