### PR TITLE
feat: add SQLJob.ssh2() / SQLJob.nodeSSH() credential-first factories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@octokit/rest": "^22.0.1",
+        "@types/ssh2": "^1.15.5",
         "@types/ws": "^8.18.1",
         "dotenv": "^17.4.2",
         "node-ssh": "^13.2.1",
@@ -695,6 +696,33 @@
       "dependencies": {
         "undici-types": "~7.21.0"
       }
+    },
+    "node_modules/@types/ssh2": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+      "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "so": "dist/index.js"
       },
       "devDependencies": {
+        "@octokit/rest": "^22.0.1",
         "@types/ws": "^8.18.1",
         "dotenv": "^17.4.2",
         "node-ssh": "^13.2.1",
@@ -136,6 +137,207 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.7.tgz",
+      "integrity": "sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.4",
+        "@octokit/request": "^10.0.13",
+        "@octokit/request-error": "^7.1.1",
+        "@octokit/types": "^17.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.4.tgz",
+      "integrity": "sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^17.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.4.tgz",
+      "integrity": "sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.13",
+        "@octokit/types": "^17.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+      "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.13.tgz",
+      "integrity": "sha512-v2269YxL9Yf+x3d+gRI63FP0vFQEiWgLyBzxe/Y+0yFDg2B/Tzf5dhh9VNfccVAQnfcfwQWyk/y6Bn7rUXXs7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.1.1",
+        "@octokit/types": "^17.0.0",
+        "content-type": "^2.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.1.tgz",
+      "integrity": "sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^17.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
+      "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-request-log": "^6.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
+      "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^28.0.0"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -960,6 +1162,13 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -1123,6 +1332,20 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -1555,6 +1778,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.10",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.10.tgz",
+      "integrity": "sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w==",
       "dev": true,
       "license": "MIT"
     },
@@ -2666,6 +2896,13 @@
       "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -32,12 +32,18 @@
   "types": "./dist/src/index.d.ts",
   "scripts": {
     "test": "vitest run --bail 5",
+    "prepack": "npx tsx scripts/downloadServer.ts",
     "webpack:dev": "webpack --mode none --config ./webpack.config.js",
     "webpack": "webpack --mode production --config ./webpack.config.js",
     "deploy": "npm run webpack && npm i && npm publish --access public"
   },
+  "files": [
+    "dist/**",
+    "src/**"
+  ],
   "author": "IBM",
   "devDependencies": {
+    "@octokit/rest": "^22.0.1",
     "@types/ws": "^8.18.1",
     "dotenv": "^17.4.2",
     "node-ssh": "^13.2.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "author": "IBM",
   "devDependencies": {
     "@octokit/rest": "^22.0.1",
+    "@types/ssh2": "^1.15.5",
     "@types/ws": "^8.18.1",
     "dotenv": "^17.4.2",
     "node-ssh": "^13.2.1",

--- a/scripts/downloadServer.ts
+++ b/scripts/downloadServer.ts
@@ -1,0 +1,110 @@
+/**
+ * Build-time script: download the pinned Mapepire server JAR from GitHub Releases,
+ * compute its SHA-256 digest, and write it back into src/serverVersion.ts.
+ *
+ * Mirrors vscode-ibmi/tools/downloadMapepire.ts with SHA-256 patch-back added.
+ *
+ * Run automatically via the "prepack" npm script before `npm pack` / `npm publish`.
+ * Never runs on the consumer's machine — the JAR ships inside the npm tarball.
+ *
+ * Usage:
+ *   npx tsx scripts/downloadServer.ts
+ */
+
+import { Octokit } from '@octokit/rest';
+import { createHash } from 'crypto';
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'fs';
+import path from 'path';
+import { SERVER_FILE_PREFIX, SERVER_VERSION_FILE, SERVER_VERSION_TAG } from '../src/serverVersion';
+
+const OWNER = 'Mapepire-IBMi';
+const REPO  = 'mapepire-server';
+
+const distDirectory  = path.join('.', 'dist');
+const serverFilePath = path.join(distDirectory, SERVER_VERSION_FILE);
+const serverVersionSrc = path.join('.', 'src', 'serverVersion.ts');
+
+function fileExists(filePath: string): boolean {
+  try { statSync(filePath); return true; } catch { return false; }
+}
+
+async function downloadFile(url: string, outputPath: string): Promise<Buffer> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to download ${url}: ${response.status} ${response.statusText}`);
+  }
+  const buffer = Buffer.from(await response.arrayBuffer());
+  writeFileSync(outputPath, buffer);
+  return buffer;
+}
+
+function computeSha256(buffer: Buffer): string {
+  return createHash('sha256').update(buffer).digest('hex');
+}
+
+function patchSha256InSource(sha256: string): void {
+  const src = readFileSync(serverVersionSrc, 'utf8');
+  const patched = src.replace(
+    /^export const JAR_SHA256 = `[^`]*`;/m,
+    `export const JAR_SHA256 = \`${sha256}\`;`
+  );
+  if (patched === src) {
+    throw new Error(`Could not find JAR_SHA256 constant in ${serverVersionSrc} to patch`);
+  }
+  writeFileSync(serverVersionSrc, patched, 'utf8');
+  console.log(`Patched JAR_SHA256 in ${serverVersionSrc}`);
+}
+
+async function work(): Promise<void> {
+  // Ensure dist/ exists
+  if (!existsSync(distDirectory)) {
+    mkdirSync(distDirectory, { recursive: true });
+  }
+
+  // Idempotent: skip download if JAR already present
+  if (fileExists(serverFilePath)) {
+    console.log(`Server JAR already present: ${SERVER_VERSION_FILE}`);
+    // Still compute and patch SHA256 in case it was cleared
+    const buffer = readFileSync(serverFilePath);
+    const sha256 = computeSha256(buffer);
+    patchSha256InSource(sha256);
+    console.log(`SHA-256: ${sha256}`);
+    return;
+  }
+
+  const octokit = new Octokit();
+
+  try {
+    console.log(`Fetching release ${SERVER_VERSION_TAG} from ${OWNER}/${REPO}…`);
+    const result = await octokit.request(
+      'GET /repos/{owner}/{repo}/releases/tags/{tag}',
+      { owner: OWNER, repo: REPO, tag: SERVER_VERSION_TAG,
+        headers: { 'X-GitHub-Api-Version': '2022-11-28' } }
+    );
+
+    // Prefer versioned name (e.g. mapepire-server-2.3.6.jar) if present,
+    // fall back to the plain mapepire-server.jar used in most releases.
+    const asset =
+      result.data.assets.find((a: any) => a.name.startsWith(SERVER_FILE_PREFIX) && a.name.endsWith('.jar')) ||
+      result.data.assets.find((a: any) => a.name === 'mapepire-server.jar');
+
+    if (!asset) {
+      throw new Error(`No .jar asset found in release ${SERVER_VERSION_TAG}`);
+    }
+
+    console.log(`Downloading ${asset.name} from ${asset.browser_download_url}…`);
+    const buffer = await downloadFile(asset.browser_download_url, serverFilePath);
+    console.log(`Saved to ${serverFilePath}`);
+
+    const sha256 = computeSha256(buffer);
+    console.log(`SHA-256: ${sha256}`);
+
+    patchSha256InSource(sha256);
+
+  } catch (e) {
+    console.error('downloadServer failed:', e);
+    process.exit(1);
+  }
+}
+
+work();

--- a/scripts/downloadServer.ts
+++ b/scripts/downloadServer.ts
@@ -13,7 +13,7 @@
 
 import { Octokit } from '@octokit/rest';
 import { createHash } from 'crypto';
-import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import path from 'path';
 import { SERVER_FILE_PREFIX, SERVER_VERSION_FILE, SERVER_VERSION_TAG } from '../src/serverVersion';
 
@@ -23,10 +23,6 @@ const REPO  = 'mapepire-server';
 const distDirectory  = path.join('.', 'dist');
 const serverFilePath = path.join(distDirectory, SERVER_VERSION_FILE);
 const serverVersionSrc = path.join('.', 'src', 'serverVersion.ts');
-
-function fileExists(filePath: string): boolean {
-  try { statSync(filePath); return true; } catch { return false; }
-}
 
 async function downloadFile(url: string, outputPath: string): Promise<Buffer> {
   const response = await fetch(url);
@@ -62,7 +58,7 @@ async function work(): Promise<void> {
   }
 
   // Idempotent: skip download if JAR already present
-  if (fileExists(serverFilePath)) {
+  if (existsSync(serverFilePath)) {
     console.log(`Server JAR already present: ${SERVER_VERSION_FILE}`);
     // Still compute and patch SHA256 in case it was cleared
     const buffer = readFileSync(serverFilePath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,5 +10,5 @@ export { SSHSingleTransport, SSHSingleTransportOptions } from "./transports/sshS
 export { LineBuffer } from "./transports/lineBuffer";
 
 // SSH Helper exports - user provides connected SSH client
-export { createSSH2Exec, createSSH2Upload, createSSH2Connection } from "./transports/ssh2Helper";
-export { createNodeSSHExec, createNodeSSHUpload, createNodeSSHConnection } from "./transports/nodeSSHHelper";
+export { createSSH2Exec, createSSH2Upload, createSSH2Connection, connectSSH2 } from "./transports/ssh2Helper";
+export { createNodeSSHExec, createNodeSSHUpload, createNodeSSHConnection, connectNodeSSH } from "./transports/nodeSSHHelper";

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,4 +12,3 @@ export { LineBuffer } from "./transports/lineBuffer";
 // SSH Helper exports - user provides connected SSH client
 export { createSSH2Exec, createSSH2Upload, createSSH2Connection } from "./transports/ssh2Helper";
 export { createNodeSSHExec, createNodeSSHUpload, createNodeSSHConnection } from "./transports/nodeSSHHelper";
-export { ensureServerInstalled, ServerInstallerOptions } from "./transports/serverInstaller";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { SQLJob } from "./sqlJob";
+export { VERSION, SERVER_VERSION_TAG, SERVER_FILE_PREFIX, SERVER_VERSION_FILE, JAR_SHA256 } from "./serverVersion";
 export { Pool } from "./pool";
 export { getCertificate, getRootCertificate } from "./tls";
 export * as States from "./states";
@@ -9,5 +10,6 @@ export { SSHSingleTransport, SSHSingleTransportOptions } from "./transports/sshS
 export { LineBuffer } from "./transports/lineBuffer";
 
 // SSH Helper exports - user provides connected SSH client
-export { createSSH2Exec } from "./transports/ssh2Helper";
-export { createNodeSSHExec } from "./transports/nodeSSHHelper";
+export { createSSH2Exec, createSSH2Upload, createSSH2Connection } from "./transports/ssh2Helper";
+export { createNodeSSHExec, createNodeSSHUpload, createNodeSSHConnection } from "./transports/nodeSSHHelper";
+export { ensureServerInstalled, ServerInstallerOptions } from "./transports/serverInstaller";

--- a/src/serverVersion.ts
+++ b/src/serverVersion.ts
@@ -1,0 +1,18 @@
+/**
+ * Pinned Mapepire server version constants.
+ * Single source of truth — imported by the build script, ServerInstaller, and tests.
+ *
+ * JAR_SHA256 is written back by scripts/downloadServer.ts at build/prepack time.
+ * It starts as an empty string and must NOT be edited by hand.
+ */
+
+export const VERSION = `2.3.6`;
+export const SERVER_VERSION_TAG = `v${VERSION}`;
+export const SERVER_FILE_PREFIX = `mapepire-server-`;
+export const SERVER_VERSION_FILE = `${SERVER_FILE_PREFIX}${VERSION}.jar`;
+
+/**
+ * SHA-256 hex digest of the bundled JAR file.
+ * Populated automatically by scripts/downloadServer.ts — do not edit manually.
+ */
+export const JAR_SHA256 = `6371d64f5684fcbee96f27107512f712fc1676ffded00726f2752dcfc30977b7`;

--- a/src/sqlJob.ts
+++ b/src/sqlJob.ts
@@ -20,6 +20,10 @@ import { ExplainType, JobStatus, TransactionEndType } from "./states";
 import { Transport } from "./transport";
 import { WebSocketTransport } from "./transports/websocket";
 import { SSHSingleTransport } from "./transports/sshSingleTransport";
+import { connectSSH2, createSSH2Connection } from "./transports/ssh2Helper";
+import { connectNodeSSH, createNodeSSHConnection } from "./transports/nodeSSHHelper";
+import type { ConnectConfig as SSH2ConnectConfig } from "ssh2";
+import type { Config as NodeSSHConfig } from "node-ssh";
 
 const TransactionCountQuery = [
   `select count(*) as thecount`,
@@ -105,6 +109,62 @@ export class SQLJob {
     (job as any)._mapepireConfig = config;
     
     return job;
+  }
+
+  /**
+   * Creates a connected SQLJob using ssh2 credentials.
+   * The SSH client is managed internally — no need to create, connect, or close it.
+   * Call job.connect() with no arguments, then job.close() when done.
+   *
+   * @param creds  - ssh2 ConnectConfig (host, username, password / privateKey, port, …)
+   * @param options - Optional JDBC options
+   * @returns SQLJob instance ready for job.connect()
+   *
+   * @example
+   * ```typescript
+   * const job = await SQLJob.ssh2({ host: 'ibmi.example.com', username: 'USER', password: 'PASS' });
+   * await job.connect();
+   * const result = await job.execute('SELECT * FROM QIWS.QCUSTCDT');
+   * await job.close();  // SSH client torn down automatically
+   * ```
+   */
+  static async ssh2(creds: SSH2ConnectConfig, options: JDBCOptions = {}): Promise<SQLJob> {
+    const client = await connectSSH2(creds);
+    return SQLJob.withConfig({
+      transport: 'ssh-single',
+      sshSingle: {
+        ...createSSH2Connection(client),
+        teardown: () => client.end(),
+      },
+    }, options);
+  }
+
+  /**
+   * Creates a connected SQLJob using node-ssh credentials.
+   * The SSH instance is managed internally — no need to create, connect, or dispose it.
+   * Call job.connect() with no arguments, then job.close() when done.
+   *
+   * @param creds  - node-ssh Config (host, username, password / privateKey, port, …)
+   * @param options - Optional JDBC options
+   * @returns SQLJob instance ready for job.connect()
+   *
+   * @example
+   * ```typescript
+   * const job = await SQLJob.nodeSSH({ host: 'ibmi.example.com', username: 'USER', password: 'PASS' });
+   * await job.connect();
+   * const result = await job.execute('SELECT * FROM QIWS.QCUSTCDT');
+   * await job.close();  // SSH instance disposed automatically
+   * ```
+   */
+  static async nodeSSH(creds: NodeSSHConfig, options: JDBCOptions = {}): Promise<SQLJob> {
+    const ssh = await connectNodeSSH(creds);
+    return SQLJob.withConfig({
+      transport: 'ssh-single',
+      sshSingle: {
+        ...createNodeSSHConnection(ssh),
+        teardown: () => ssh.dispose(),
+      },
+    }, options);
   }
 
   /**

--- a/src/transports/README.md
+++ b/src/transports/README.md
@@ -18,47 +18,133 @@ await job.connect({
 ```
 
 ### 2. SSH Single Transport
-Launch mapepire-server in single mode via SSH. No daemon required.
+Launch mapepire-server in single mode via SSH. No daemon required. The simplest path uses
+`createSSH2Connection` which enables private install automatically — no pre-installed server needed.
 
 ```typescript
 import { Client } from 'ssh2';
-import { SQLJob, createSSH2Exec } from '@ibm/mapepire-js';
+import { SQLJob, createSSH2Connection } from '@ibm/mapepire-js';
 
-// 1. Connect SSH client
 const client = new Client();
+// ... connect client ...
 
-// 2. Create job with helper - no manual exec function needed!
 const job = SQLJob.withConfig({
   transport: 'ssh-single',
-  sshSingle: {
-    exec: createSSH2Exec(client),
-    serverPath: '/path/to/mapepire-server.jar'
-  }
+  sshSingle: createSSH2Connection(client),  // private install enabled automatically
 });
 
-// 3. Use normally
-await job.connect();
+await job.connect();  // installs JAR to $HOME/.mapepire if needed, then connects
 const result = await job.execute('SELECT * FROM QIWS.QCUSTCDT');
 await job.close();
 client.end();
 ```
 
-## SSH Helpers
+Need extra options? Spread the connection alongside them:
 
-Built-in helpers for ssh2 and node-ssh libraries simplify SSH integration:
-
-### ssh2 Helper
 ```typescript
-import { createSSH2Exec } from '@ibm/mapepire-js';
-
-const exec = createSSH2Exec(connectedClient);
+const job = SQLJob.withConfig({
+  transport: 'ssh-single',
+  sshSingle: {
+    ...createSSH2Connection(client),
+    javaPath: '/QOpenSys/QIBM/ProdData/JavaVM/jdk17/64bit/bin/java',
+    startupTimeout: 20000,
+  },
+});
 ```
 
-### node-ssh Helper
-```typescript
-import { createNodeSSHExec } from '@ibm/mapepire-js';
+### Private Install — how it works
 
-const exec = createNodeSSHExec(connectedSSH);
+`createSSH2Connection` (and `createNodeSSHConnection`) bundles both `exec` and `upload` so
+mapepire-js can manage the server JAR automatically:
+
+1. Searches `$HOME/.mapepire` **and** `$HOME/.vscode` (vscode-ibmi's location) for any existing JAR
+2. If a version **≥ bundled** is found → uses it as-is, no upload
+3. If nothing usable is found → uploads the bundled JAR to `$HOME/.mapepire/`, verifies its
+   SHA-256, then launches
+
+SHA-256 is only verified on a JAR we just uploaded — not on a pre-existing remote JAR, because
+`JAR_SHA256` is specific to the bundled version and cannot vouch for any other version's bytes.
+
+If `serverPath` is explicitly set, private install is skipped entirely (caller manages the path).
+
+## SSH Helpers
+
+Built-in helpers for ssh2 and node-ssh libraries:
+
+| Function | Returns | Use when |
+|---|---|---|
+| `createSSH2Connection(client)` | `{ exec, upload }` | **Default** — private install enabled automatically |
+| `createNodeSSHConnection(ssh)` | `{ exec, upload }` | **Default** — node-ssh variant |
+| `createSSH2Exec(client)` | `ExecFunction` | Advanced — you supply `serverPath` explicitly |
+| `createSSH2Upload(client)` | `UploadFunction` | Advanced — compose `exec` + `upload` manually |
+| `createNodeSSHExec(ssh)` | `ExecFunction` | Advanced — you supply `serverPath` explicitly |
+| `createNodeSSHUpload(ssh)` | `UploadFunction` | Advanced — compose `exec` + `upload` manually |
+
+### Default usage (recommended)
+
+Pass the result of `createSSH2Connection` / `createNodeSSHConnection` directly to `sshSingle`.
+Private install is enabled automatically — no extra options required.
+
+**ssh2:**
+```typescript
+import { Client } from 'ssh2';
+import { SQLJob, createSSH2Connection } from '@ibm/mapepire-js';
+
+const client = new Client();
+// ... connect client ...
+
+const job = SQLJob.withConfig({
+  transport: 'ssh-single',
+  sshSingle: createSSH2Connection(client),
+});
+await job.connect();
+```
+
+**node-ssh:**
+```typescript
+import { NodeSSH } from 'node-ssh';
+import { SQLJob, createNodeSSHConnection } from '@ibm/mapepire-js';
+
+const ssh = new NodeSSH();
+await ssh.connect({ host: 'ibmi.example.com', username: 'user', password: 'pass' });
+
+const job = SQLJob.withConfig({
+  transport: 'ssh-single',
+  sshSingle: createNodeSSHConnection(ssh),
+});
+await job.connect();
+```
+
+Need extra options (`javaPath`, `startupTimeout`, etc.)? Spread the connection:
+
+```typescript
+sshSingle: {
+  ...createSSH2Connection(client),   // or createNodeSSHConnection(ssh)
+  javaPath: '/QOpenSys/QIBM/ProdData/JavaVM/jdk17/64bit/bin/java',
+  startupTimeout: 20000,
+}
+```
+
+### Advanced usage — explicit exec + upload
+
+Use `createSSH2Exec` / `createSSH2Upload` (or their node-ssh equivalents) directly when you need
+to compose them separately — for example, to use a different upload mechanism or to opt out of
+private install entirely by setting `serverPath`.
+
+```typescript
+import { createSSH2Exec, createSSH2Upload } from '@ibm/mapepire-js';
+
+// Private install with manually composed helpers (equivalent to createSSH2Connection)
+sshSingle: {
+  exec:   createSSH2Exec(client),
+  upload: createSSH2Upload(client),
+}
+
+// Opt out of private install — bring your own JAR path
+sshSingle: {
+  exec:       createSSH2Exec(client),
+  serverPath: '/opt/mapepire/lib/mapepire/mapepire-server.jar',
+}
 ```
 
 **Key Principle:** You manage SSH connections, we handle protocol mapping.
@@ -71,6 +157,8 @@ interface SSHSingleConfig {
   exec: ExecFunction;           // Required: SSH exec function
   serverPath?: string;          // Optional: Path to JAR on IBM i
                                 //   default: /opt/mapepire/lib/mapepire/mapepire-server.jar
+  upload?: UploadFunction;      // Optional: enables private install (see above)
+  privateInstallDir?: string;   // Optional: override install dir (default: $HOME/.mapepire)
   javaPath?: string;            // Optional: Java path
                                 //   default: /QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit/bin/java
   jvmArgs?: string[];           // Optional: Additional JVM arguments
@@ -79,6 +167,29 @@ interface SSHSingleConfig {
   startupTimeout?: number;      // Optional: Startup timeout (default: 10000ms)
 }
 ```
+
+## Updating the Bundled Server Version
+
+The bundled JAR version is pinned in [`src/serverVersion.ts`](../serverVersion.ts). To upgrade:
+
+1. **Edit `VERSION`** in `src/serverVersion.ts`:
+   ```typescript
+   export const VERSION = `2.3.7`;  // bump to the new release tag
+   ```
+   Do **not** edit `JAR_SHA256` — the build script overwrites it automatically.
+
+2. **Run the download script** (or just `npm run prepack`):
+   ```sh
+   npx tsx scripts/downloadServer.ts
+   ```
+   This fetches `mapepire-server-2.3.7.jar` from GitHub Releases, saves it to `dist/`, computes
+   its SHA-256, and patches `JAR_SHA256` back into `src/serverVersion.ts`.
+
+3. **Commit both changed files** — `src/serverVersion.ts` and `dist/mapepire-server-X.Y.Z.jar` —
+   then publish.
+
+> The JAR ships inside the npm tarball. Consumers never run the download script; they get the
+> pre-bundled JAR when they `npm install`.
 
 ## Files
 
@@ -91,8 +202,9 @@ interface SSHSingleConfig {
 ## Tests
 
 Comprehensive test coverage available:
-- [`test/sshHelpers.test.ts`](../../test/sshHelpers.test.ts) - SSH helper tests (15 test cases)
+- [`test/sshHelpers.test.ts`](../../test/sshHelpers.test.ts) - SSH helper unit + integration tests
 - [`test/sshSingleTransport.test.ts`](../../test/sshSingleTransport.test.ts) - Transport layer tests
+- [`test/serverInstaller.test.ts`](../../test/serverInstaller.test.ts) - Private install logic (10 test cases)
 
 ## Quick Comparison
 

--- a/src/transports/README.md
+++ b/src/transports/README.md
@@ -21,38 +21,33 @@ await job.connect({
 Launch mapepire-server in single mode via SSH. No daemon required. Private install is enabled
 automatically — no pre-installed server needed.
 
-**ssh2** (simplest):
+**Credential-first (recommended)** — SSH client lifecycle managed internally:
+```typescript
+import { SQLJob } from '@ibm/mapepire-js';
+
+// ssh2
+const job = await SQLJob.ssh2({ host: 'ibmi.example.com', username: 'USER', password: 'PASS' });
+await job.connect();
+const result = await job.execute('SELECT * FROM QIWS.QCUSTCDT');
+await job.close();  // SSH client torn down automatically
+
+// node-ssh
+const job = await SQLJob.nodeSSH({ host: 'ibmi.example.com', username: 'USER', password: 'PASS' });
+await job.connect();
+const result = await job.execute('SELECT * FROM QIWS.QCUSTCDT');
+await job.close();  // SSH instance disposed automatically
+```
+
+**Bring your own client** — useful when reusing an existing SSH connection:
 ```typescript
 import { SQLJob, connectSSH2, createSSH2Connection } from '@ibm/mapepire-js';
 
 const client = await connectSSH2({ host: 'ibmi.example.com', username: 'USER', password: 'PASS' });
-
-const job = SQLJob.withConfig({
-  transport: 'ssh-single',
-  sshSingle: createSSH2Connection(client),
-});
-
-await job.connect();  // installs JAR to $HOME/.mapepire if needed, then connects
-const result = await job.execute('SELECT * FROM QIWS.QCUSTCDT');
-await job.close();
-client.end();
-```
-
-**node-ssh** (simplest):
-```typescript
-import { SQLJob, connectNodeSSH, createNodeSSHConnection } from '@ibm/mapepire-js';
-
-const ssh = await connectNodeSSH({ host: 'ibmi.example.com', username: 'USER', password: 'PASS' });
-
-const job = SQLJob.withConfig({
-  transport: 'ssh-single',
-  sshSingle: createNodeSSHConnection(ssh),
-});
-
+const job = SQLJob.withConfig({ transport: 'ssh-single', sshSingle: createSSH2Connection(client) });
 await job.connect();
 const result = await job.execute('SELECT * FROM QIWS.QCUSTCDT');
 await job.close();
-ssh.dispose();
+client.end();  // caller manages SSH client lifetime
 ```
 
 Need extra options? Spread the connection alongside them:
@@ -89,10 +84,12 @@ Built-in helpers for ssh2 and node-ssh libraries:
 
 | Function | Returns | Use when |
 |---|---|---|
-| `connectSSH2(options)` | `Promise<Client>` | **Recommended** — connect + get a ready Client in one call |
-| `connectNodeSSH(options)` | `Promise<NodeSSH>` | **Recommended** — node-ssh variant |
-| `createSSH2Connection(client)` | `{ exec, upload }` | You already have a connected Client |
-| `createNodeSSHConnection(ssh)` | `{ exec, upload }` | You already have a connected NodeSSH |
+| `SQLJob.ssh2(creds, opts?)` | `Promise<SQLJob>` | **Simplest** — credentials in, job out, SSH lifecycle managed internally |
+| `SQLJob.nodeSSH(creds, opts?)` | `Promise<SQLJob>` | **Simplest** — node-ssh variant |
+| `connectSSH2(options)` | `Promise<Client>` | Connect + get a ready Client in one call |
+| `connectNodeSSH(options)` | `Promise<NodeSSH>` | node-ssh variant |
+| `createSSH2Connection(client)` | `{ exec, upload }` | Single job — you already have a connected Client |
+| `createNodeSSHConnection(ssh)` | `{ exec, upload }` | Single job — you already have a connected NodeSSH |
 | `createSSH2Exec(client)` | `ExecFunction` | Advanced — you supply `serverPath` explicitly |
 | `createSSH2Upload(client)` | `UploadFunction` | Advanced — compose `exec` + `upload` manually |
 | `createNodeSSHExec(ssh)` | `ExecFunction` | Advanced — you supply `serverPath` explicitly |

--- a/src/transports/README.md
+++ b/src/transports/README.md
@@ -18,25 +18,41 @@ await job.connect({
 ```
 
 ### 2. SSH Single Transport
-Launch mapepire-server in single mode via SSH. No daemon required. The simplest path uses
-`createSSH2Connection` which enables private install automatically — no pre-installed server needed.
+Launch mapepire-server in single mode via SSH. No daemon required. Private install is enabled
+automatically — no pre-installed server needed.
 
+**ssh2** (simplest):
 ```typescript
-import { Client } from 'ssh2';
-import { SQLJob, createSSH2Connection } from '@ibm/mapepire-js';
+import { SQLJob, connectSSH2, createSSH2Connection } from '@ibm/mapepire-js';
 
-const client = new Client();
-// ... connect client ...
+const client = await connectSSH2({ host: 'ibmi.example.com', username: 'USER', password: 'PASS' });
 
 const job = SQLJob.withConfig({
   transport: 'ssh-single',
-  sshSingle: createSSH2Connection(client),  // private install enabled automatically
+  sshSingle: createSSH2Connection(client),
 });
 
 await job.connect();  // installs JAR to $HOME/.mapepire if needed, then connects
 const result = await job.execute('SELECT * FROM QIWS.QCUSTCDT');
 await job.close();
 client.end();
+```
+
+**node-ssh** (simplest):
+```typescript
+import { SQLJob, connectNodeSSH, createNodeSSHConnection } from '@ibm/mapepire-js';
+
+const ssh = await connectNodeSSH({ host: 'ibmi.example.com', username: 'USER', password: 'PASS' });
+
+const job = SQLJob.withConfig({
+  transport: 'ssh-single',
+  sshSingle: createNodeSSHConnection(ssh),
+});
+
+await job.connect();
+const result = await job.execute('SELECT * FROM QIWS.QCUSTCDT');
+await job.close();
+ssh.dispose();
 ```
 
 Need extra options? Spread the connection alongside them:
@@ -73,56 +89,23 @@ Built-in helpers for ssh2 and node-ssh libraries:
 
 | Function | Returns | Use when |
 |---|---|---|
-| `createSSH2Connection(client)` | `{ exec, upload }` | **Default** — private install enabled automatically |
-| `createNodeSSHConnection(ssh)` | `{ exec, upload }` | **Default** — node-ssh variant |
+| `connectSSH2(options)` | `Promise<Client>` | **Recommended** — connect + get a ready Client in one call |
+| `connectNodeSSH(options)` | `Promise<NodeSSH>` | **Recommended** — node-ssh variant |
+| `createSSH2Connection(client)` | `{ exec, upload }` | You already have a connected Client |
+| `createNodeSSHConnection(ssh)` | `{ exec, upload }` | You already have a connected NodeSSH |
 | `createSSH2Exec(client)` | `ExecFunction` | Advanced — you supply `serverPath` explicitly |
 | `createSSH2Upload(client)` | `UploadFunction` | Advanced — compose `exec` + `upload` manually |
 | `createNodeSSHExec(ssh)` | `ExecFunction` | Advanced — you supply `serverPath` explicitly |
 | `createNodeSSHUpload(ssh)` | `UploadFunction` | Advanced — compose `exec` + `upload` manually |
 
-### Default usage (recommended)
+### Already have a connected client?
 
-Pass the result of `createSSH2Connection` / `createNodeSSHConnection` directly to `sshSingle`.
-Private install is enabled automatically — no extra options required.
-
-**ssh2:**
-```typescript
-import { Client } from 'ssh2';
-import { SQLJob, createSSH2Connection } from '@ibm/mapepire-js';
-
-const client = new Client();
-// ... connect client ...
-
-const job = SQLJob.withConfig({
-  transport: 'ssh-single',
-  sshSingle: createSSH2Connection(client),
-});
-await job.connect();
-```
-
-**node-ssh:**
-```typescript
-import { NodeSSH } from 'node-ssh';
-import { SQLJob, createNodeSSHConnection } from '@ibm/mapepire-js';
-
-const ssh = new NodeSSH();
-await ssh.connect({ host: 'ibmi.example.com', username: 'user', password: 'pass' });
-
-const job = SQLJob.withConfig({
-  transport: 'ssh-single',
-  sshSingle: createNodeSSHConnection(ssh),
-});
-await job.connect();
-```
-
-Need extra options (`javaPath`, `startupTimeout`, etc.)? Spread the connection:
+Pass it straight to `createSSH2Connection` / `createNodeSSHConnection` — useful when you're
+reusing an existing SSH connection across multiple jobs:
 
 ```typescript
-sshSingle: {
-  ...createSSH2Connection(client),   // or createNodeSSHConnection(ssh)
-  javaPath: '/QOpenSys/QIBM/ProdData/JavaVM/jdk17/64bit/bin/java',
-  startupTimeout: 20000,
-}
+sshSingle: createSSH2Connection(client)       // ssh2
+sshSingle: createNodeSSHConnection(ssh)       // node-ssh
 ```
 
 ### Advanced usage — explicit exec + upload

--- a/src/transports/nodeSSHHelper.ts
+++ b/src/transports/nodeSSHHelper.ts
@@ -1,12 +1,12 @@
 /**
  * node-ssh Helper for Mapepire SSH Single Transport
  *
- * This module provides a ready-made utility for using node-ssh library with Mapepire.
- * Simply pass your connected NodeSSH instance to get a configured exec function.
+ * This module provides ready-made utilities for using node-ssh library with Mapepire.
+ * Pass your connected NodeSSH instance to get an exec or upload function.
  */
 
 import type { NodeSSH } from 'node-ssh';
-import type { ExecFunction, ExecChannel } from '../types';
+import type { ExecFunction, ExecChannel, UploadFunction, SSHSingleConfig } from '../types';
 
 /**
  * Creates an exec function from a connected NodeSSH instance.
@@ -24,15 +24,9 @@ import type { ExecFunction, ExecChannel } from '../types';
  * import { NodeSSH } from 'node-ssh';
  * import { SQLJob, createNodeSSHExec } from '@ibm/mapepire-js';
  *
- * // User manages SSH connection
  * const ssh = new NodeSSH();
- * await ssh.connect({
- *   host: 'your-host.com',
- *   username: 'user',
- *   password: 'pass'
- * });
+ * await ssh.connect({ host: 'your-host.com', username: 'user', password: 'pass' });
  *
- * // Pass connected client to Mapepire
  * const job = SQLJob.withConfig({
  *   transport: 'ssh-single',
  *   sshSingle: {
@@ -44,8 +38,6 @@ import type { ExecFunction, ExecChannel } from '../types';
  * await job.connect();
  * // ... use job ...
  * await job.close();
- *
- * // User closes SSH connection
  * ssh.dispose();
  * ```
  */
@@ -61,33 +53,97 @@ export function createNodeSSHExec(ssh: NodeSSH): ExecFunction {
     if (!client) {
       throw new Error('NodeSSH instance is not connected');
     }
-    
+
     return new Promise((resolve, reject) => {
       client.exec(command, (err, stream) => {
         if (err) {
           reject(err);
           return;
         }
-        
+
         const channel: ExecChannel = {
           stdin: stream.stdin,
           stdout: stream,
           stderr: stream.stderr,
-          
+
           close() {
             stream.close();
             // Note: We don't dispose the ssh connection here as the user manages it
           },
-          
+
           onExit(callback) {
             stream.on('close', (code, signal) => {
               callback(code, signal);
             });
           }
         };
-        
+
         resolve(channel);
       });
     });
+  };
+}
+
+/**
+ * Creates an upload function from a connected NodeSSH instance.
+ * Uses node-ssh's built-in putFile for SFTP transfer.
+ *
+ * The user is responsible for:
+ * - The NodeSSH instance being connected before calling this
+ * - Disposing the connection when done
+ *
+ * @param ssh - Connected NodeSSH instance
+ * @returns UploadFunction that can be used with SSHSingleConfig.upload
+ *
+ * @example
+ * ```typescript
+ * import { NodeSSH } from 'node-ssh';
+ * import { SQLJob, createNodeSSHExec, createNodeSSHUpload } from '@ibm/mapepire-js';
+ *
+ * const job = SQLJob.withConfig({
+ *   transport: 'ssh-single',
+ *   sshSingle: {
+ *     exec: createNodeSSHExec(ssh),
+ *     upload: createNodeSSHUpload(ssh),  // enables private install
+ *   }
+ * });
+ * ```
+ */
+export function createNodeSSHUpload(ssh: NodeSSH): UploadFunction {
+  return async function upload(localPath: string, remotePath: string): Promise<void> {
+    await ssh.putFile(localPath, remotePath);
+  };
+}
+
+/**
+ * Convenience wrapper: returns both `exec` and `upload` from a single connected NodeSSH instance.
+ * Spread the result directly into `sshSingle` to enable private install with one call.
+ *
+ * @param ssh - Connected NodeSSH instance
+ * @returns `{ exec, upload }` ready to spread into SSHSingleConfig
+ *
+ * @example
+ * ```typescript
+ * import { NodeSSH } from 'node-ssh';
+ * import { SQLJob, createNodeSSHConnection } from '@ibm/mapepire-js';
+ *
+ * const ssh = new NodeSSH();
+ * await ssh.connect({ host: 'your-host.com', username: 'user', password: 'pass' });
+ *
+ * const job = SQLJob.withConfig({
+ *   transport: 'ssh-single',
+ *   sshSingle: createNodeSSHConnection(ssh),  // private install enabled automatically
+ * });
+ *
+ * await job.connect();
+ * // ... use job ...
+ * await job.close();
+ * ssh.dispose();
+ * ```
+ */
+export function createNodeSSHConnection(ssh: NodeSSH): Pick<SSHSingleConfig, 'exec' | 'upload'> {
+  return {
+    exec:   createNodeSSHExec(ssh),
+    upload: createNodeSSHUpload(ssh),
   };
 }

--- a/src/transports/nodeSSHHelper.ts
+++ b/src/transports/nodeSSHHelper.ts
@@ -5,7 +5,7 @@
  * Pass your connected NodeSSH instance to get an exec or upload function.
  */
 
-import type { NodeSSH } from 'node-ssh';
+import type { NodeSSH, Config as NodeSSHConfig } from 'node-ssh';
 import type { ExecFunction, ExecChannel, UploadFunction, SSHSingleConfig } from '../types';
 
 /**
@@ -146,4 +146,35 @@ export function createNodeSSHConnection(ssh: NodeSSH): Pick<SSHSingleConfig, 'ex
     exec:   createNodeSSHExec(ssh),
     upload: createNodeSSHUpload(ssh),
   };
+}
+
+/**
+ * Connects a NodeSSH instance using the given options and returns it.
+ * Pass the result straight to `createNodeSSHConnection`.
+ * You are responsible for calling `ssh.dispose()` when done.
+ *
+ * @param options - node-ssh Config (host, username, password / privateKey, port, …)
+ * @returns Connected NodeSSH instance
+ *
+ * @example
+ * ```typescript
+ * import { SQLJob, connectNodeSSH, createNodeSSHConnection } from '@ibm/mapepire-js';
+ *
+ * const ssh = await connectNodeSSH({ host: 'ibmi.example.com', username: 'USER', password: 'PASS' });
+ *
+ * const job = SQLJob.withConfig({
+ *   transport: 'ssh-single',
+ *   sshSingle: createNodeSSHConnection(ssh),
+ * });
+ *
+ * await job.connect();
+ * // ... use job ...
+ * await job.close();
+ * ssh.dispose();
+ * ```
+ */
+export function connectNodeSSH(options: NodeSSHConfig): Promise<NodeSSH> {
+  const { NodeSSH: NodeSSHClass } = require('node-ssh') as typeof import('node-ssh');
+  const ssh = new NodeSSHClass();
+  return ssh.connect(options).then(() => ssh);
 }

--- a/src/transports/serverInstaller.ts
+++ b/src/transports/serverInstaller.ts
@@ -87,25 +87,22 @@ function semVerLessThan(a: SemVer, b: SemVer): boolean {
  * Returns trimmed stdout. Throws on non-zero exit.
  */
 async function runCommand(exec: ExecFunction, command: string): Promise<string> {
+  const channel = await exec(command);
   return new Promise((resolve, reject) => {
-    exec(command)
-      .then(channel => {
-        let stdout = '';
-        let stderr = '';
+    let stdout = '';
+    let stderr = '';
 
-        channel.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8'); });
-        channel.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8'); });
+    channel.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8'); });
+    channel.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8'); });
 
-        channel.onExit((code) => {
-          channel.close();
-          if (code !== 0) {
-            reject(new Error(`Command "${command}" exited with code ${code}: ${stderr.trim()}`));
-          } else {
-            resolve(stdout.trim());
-          }
-        });
-      })
-      .catch(reject);
+    channel.onExit((code) => {
+      channel.close();
+      if (code !== 0) {
+        reject(new Error(`Command "${command}" exited with code ${code}: ${stderr.trim()}`));
+      } else {
+        resolve(stdout.trim());
+      }
+    });
   });
 }
 
@@ -136,7 +133,10 @@ async function checkRemoteVersions(
       `/QOpenSys/usr/bin/find "${installDir}" "${vscodePath}" -type f -name "${SERVER_FILE_PREFIX}*.jar" 2>/dev/null`
     );
   } catch {
-    // Directories don't exist or find failed — treat as no files found
+    // Silently treat as no files found. The most common cause is that the
+    // directories don't exist yet (first install). A genuine permissions error
+    // will surface on the subsequent upload attempt (mkdir / sftp), so the
+    // real problem is not swallowed permanently — just deferred one step.
     return [];
   }
 

--- a/src/transports/serverInstaller.ts
+++ b/src/transports/serverInstaller.ts
@@ -1,0 +1,244 @@
+/**
+ * ServerInstaller — private install of the Mapepire server JAR over SSH.
+ *
+ * On first connect (or after version upgrade), automatically installs the
+ * bundled server JAR to $HOME/.mapepire/ on the remote IBM i system.
+ *
+ * The install lifecycle (version check → upload → SHA-256 verify) is
+ * inspired by the equivalent feature in codefori/vscode-ibmi.
+ *
+ * Algorithm:
+ *   1. Resolve $HOME via exec("echo $HOME")
+ *   2. installDir = $HOME/.mapepire  (or overridden via remoteInstallDir)
+ *   3. find all mapepire-server-*.jar in installDir
+ *   4. Parse semver from each filename
+ *   5a. None found      → NotInstalled → upload
+ *   5b. ALL < bundled   → NeedsUpdate  → upload
+ *   5c. ANY >= bundled  → Installed    → verify SHA-256 → return path
+ *   6. Upload: mkdir -p, sftp/scp, chmod +x
+ *   7. Verify: openssl dgst -sha256 <remote>, compare to jarSha256
+ */
+
+import path from 'path';
+import type { ExecFunction, UploadFunction } from '../types';
+import { SERVER_FILE_PREFIX } from '../serverVersion';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface ServerInstallerOptions {
+  /** SSH exec function (from createSSH2Exec or createNodeSSHExec) */
+  exec: ExecFunction;
+
+  /** SFTP upload function (from createSSH2Upload or createNodeSSHUpload) */
+  upload: UploadFunction;
+
+  /** Absolute local path to the bundled JAR file */
+  localJarPath: string;
+
+  /** Semver string of the bundled JAR, e.g. "2.3.5" */
+  version: string;
+
+  /** Expected SHA-256 hex digest of the bundled JAR (from JAR_SHA256 in serverVersion.ts).
+   *  If empty string, SHA-256 verification is skipped. */
+  jarSha256: string;
+
+  /** Override for the remote install directory.
+   *  Defaults to $HOME/.mapepire on the remote IBM i system. */
+  remoteInstallDir?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Internal semver helpers
+// ---------------------------------------------------------------------------
+
+interface SemVer { major: number; minor: number; patch: number; }
+
+/** Parse "mapepire-server-X.Y.Z.jar" → SemVer, or null if unrecognised */
+function parseVersionFromFilename(filename: string): SemVer | null {
+  const m = new RegExp(`${SERVER_FILE_PREFIX}(\\d+)\\.(\\d+)\\.(\\d+)\\.jar$`).exec(filename);
+  if (!m) return null;
+  return { major: Number(m[1]), minor: Number(m[2]), patch: Number(m[3]) };
+}
+
+/** Parse "X.Y.Z" → SemVer, throws if malformed */
+function parseSemVer(version: string): SemVer {
+  const parts = version.split('.').map(Number);
+  if (parts.length !== 3 || parts.some(isNaN)) {
+    throw new Error(`Invalid semver string: "${version}"`);
+  }
+  return { major: parts[0], minor: parts[1], patch: parts[2] };
+}
+
+/** Returns true if a < b */
+function semVerLessThan(a: SemVer, b: SemVer): boolean {
+  if (a.major !== b.major) return a.major < b.major;
+  if (a.minor !== b.minor) return a.minor < b.minor;
+  return a.patch < b.patch;
+}
+
+// ---------------------------------------------------------------------------
+// Remote helpers — each runs one SSH command via exec, returns stdout
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a simple command that is expected to succeed (exit code 0).
+ * Returns trimmed stdout. Throws on non-zero exit.
+ */
+async function runCommand(exec: ExecFunction, command: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    exec(command)
+      .then(channel => {
+        let stdout = '';
+        let stderr = '';
+
+        channel.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8'); });
+        channel.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8'); });
+
+        channel.onExit((code) => {
+          channel.close();
+          if (code !== 0) {
+            reject(new Error(`Command "${command}" exited with code ${code}: ${stderr.trim()}`));
+          } else {
+            resolve(stdout.trim());
+          }
+        });
+      })
+      .catch(reject);
+  });
+}
+
+/** Step 1: Resolve $HOME on the remote system via SSH exec. */
+async function resolveHomeDir(exec: ExecFunction): Promise<string> {
+  const home = await runCommand(exec, 'echo $HOME');
+  if (!home) {
+    throw new Error('Could not resolve $HOME on remote system');
+  }
+  return home;
+}
+
+/**
+ * Step 3: Find all mapepire-server-*.jar files in known install locations.
+ * Searches both $HOME/.mapepire (our location) and $HOME/.vscode (vscode-ibmi location)
+ * in a single find call so existing vscode-ibmi installs are reused without re-uploading.
+ */
+async function checkRemoteVersions(
+  exec: ExecFunction,
+  homeDir: string,
+  installDir: string
+): Promise<Array<{ semver: SemVer; fullPath: string }>> {
+  const vscodePath = path.posix.join(homeDir, '.vscode');
+  let stdout: string;
+  try {
+    stdout = await runCommand(
+      exec,
+      `/QOpenSys/usr/bin/find "${installDir}" "${vscodePath}" -type f -name "${SERVER_FILE_PREFIX}*.jar" 2>/dev/null`
+    );
+  } catch {
+    // Directories don't exist or find failed — treat as no files found
+    return [];
+  }
+
+  return stdout
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0)
+    .map(fullPath => {
+      const filename = path.posix.basename(fullPath);
+      const semver = parseVersionFromFilename(filename);
+      return semver ? { semver, fullPath } : null;
+    })
+    .filter((x): x is { semver: SemVer; fullPath: string } => x !== null);
+}
+
+/** Step 6a: Ensure the remote install directory exists */
+async function ensureRemoteDir(exec: ExecFunction, installDir: string): Promise<void> {
+  await runCommand(exec, `mkdir -p "${installDir}"`);
+}
+
+/** Step 6b+c: Upload the JAR and make it executable */
+async function uploadJar(
+  exec: ExecFunction,
+  upload: UploadFunction,
+  localPath: string,
+  remotePath: string
+): Promise<void> {
+  await upload(localPath, remotePath);
+  await runCommand(exec, `chmod +x "${remotePath}"`);
+}
+
+/**
+ * Step 7: Verify the remote JAR's SHA-256 hash via openssl.
+ */
+async function verifySha256(
+  exec: ExecFunction,
+  remotePath: string,
+  expectedSha256: string
+): Promise<void> {
+  const output = await runCommand(exec, `openssl dgst -sha256 "${remotePath}"`);
+  // openssl output: "SHA256(filename)= <hex>"  — take the last token
+  const actual = output.split(' ').pop()?.toLowerCase() ?? '';
+  if (actual !== expectedSha256.toLowerCase()) {
+    throw new Error(
+      `Remote JAR SHA-256 mismatch — possible tampering.\n` +
+      `  expected: ${expectedSha256}\n` +
+      `  actual:   ${actual}`
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Ensure the correct version of mapepire-server is installed on the remote system.
+ * Installs to $HOME/.mapepire/ if not already present or if outdated.
+ *
+ * @returns The confirmed absolute remote path to the JAR.
+ */
+export async function ensureServerInstalled(options: ServerInstallerOptions): Promise<string> {
+  const { exec, upload, localJarPath, version, jarSha256 } = options;
+
+  // 1. Resolve home dir
+  const homeDir = await resolveHomeDir(exec);
+
+  // 2. Build install directory path
+  const installDir = options.remoteInstallDir
+    ? options.remoteInstallDir
+    : path.posix.join(homeDir, '.mapepire');
+
+  const remoteJarName = `${SERVER_FILE_PREFIX}${version}.jar`;
+  const remoteJarPath = path.posix.join(installDir, remoteJarName);
+
+  const bundledVersion = parseSemVer(version);
+
+  // 3–4. Check what's already on the remote
+  const found = await checkRemoteVersions(exec, homeDir, installDir);
+
+  const needsUpload =
+    found.length === 0 ||
+    found.every(({ semver }) => semVerLessThan(semver, bundledVersion));
+
+  if (needsUpload) {
+    // 6. Upload the bundled JAR.
+    await ensureRemoteDir(exec, installDir);
+    await uploadJar(exec, upload, localJarPath, remoteJarPath);
+
+    // 7. Verify the JAR we just uploaded against the known bundled hash.
+    //    Skipped only when jarSha256 is empty (e.g. pre-build dev run).
+    //    We do NOT verify pre-existing remote JARs — JAR_SHA256 is specific
+    //    to the bundled version and cannot vouch for any other version's bytes.
+    if (jarSha256) {
+      await verifySha256(exec, remoteJarPath, jarSha256);
+    }
+
+    return remoteJarPath;
+  }
+
+  // Installed: at least one found version >= bundled.
+  // Return the highest found version's actual path.
+  const best = found.reduce((a, b) => semVerLessThan(a.semver, b.semver) ? b : a);
+  return best.fullPath;
+}

--- a/src/transports/ssh2Helper.ts
+++ b/src/transports/ssh2Helper.ts
@@ -5,7 +5,7 @@
  * Pass your connected ssh2 Client instance to get an exec or upload function.
  */
 
-import type { Client } from 'ssh2';
+import type { Client, ConnectConfig } from 'ssh2';
 import type { ExecFunction, ExecChannel, UploadFunction, SSHSingleConfig } from '../types';
 
 /**
@@ -143,4 +143,39 @@ export function createSSH2Connection(client: Client): Pick<SSHSingleConfig, 'exe
     exec:   createSSH2Exec(client),
     upload: createSSH2Upload(client),
   };
+}
+
+/**
+ * Promisifies the ssh2 Client connect lifecycle.
+ * Returns the connected Client — pass it straight to `createSSH2Connection`.
+ * You are responsible for calling `client.end()` when done.
+ *
+ * @param options - ssh2 ConnectConfig (host, username, password / privateKey, port, …)
+ * @returns Connected ssh2 Client instance
+ *
+ * @example
+ * ```typescript
+ * import { SQLJob, connectSSH2, createSSH2Connection } from '@ibm/mapepire-js';
+ *
+ * const client = await connectSSH2({ host: 'ibmi.example.com', username: 'USER', password: 'PASS' });
+ *
+ * const job = SQLJob.withConfig({
+ *   transport: 'ssh-single',
+ *   sshSingle: createSSH2Connection(client),
+ * });
+ *
+ * await job.connect();
+ * // ... use job ...
+ * await job.close();
+ * client.end();
+ * ```
+ */
+export function connectSSH2(options: ConnectConfig): Promise<Client> {
+  return new Promise((resolve, reject) => {
+    const { Client: SSH2Client } = require('ssh2') as typeof import('ssh2');
+    const client = new SSH2Client();
+    client.on('ready', () => resolve(client));
+    client.on('error', reject);
+    client.connect(options);
+  });
 }

--- a/src/transports/ssh2Helper.ts
+++ b/src/transports/ssh2Helper.ts
@@ -103,6 +103,8 @@ export function createSSH2Upload(client: Client): UploadFunction {
       client.sftp((err, sftp) => {
         if (err) { reject(err); return; }
         sftp.fastPut(localPath, remotePath, (putErr) => {
+          // Close SFTP session so the remote end flushes the file before we return.
+          sftp.end();
           if (putErr) { reject(putErr); } else { resolve(); }
         });
       });

--- a/src/transports/ssh2Helper.ts
+++ b/src/transports/ssh2Helper.ts
@@ -1,12 +1,12 @@
 /**
  * SSH2 Helper for Mapepire SSH Single Transport
  *
- * This module provides a ready-made utility for using ssh2 library with Mapepire.
- * Simply pass your connected ssh2 Client instance to get a configured exec function.
+ * This module provides ready-made utilities for using the ssh2 library with Mapepire.
+ * Pass your connected ssh2 Client instance to get an exec or upload function.
  */
 
 import type { Client } from 'ssh2';
-import type { ExecFunction, ExecChannel } from '../types';
+import type { ExecFunction, ExecChannel, UploadFunction, SSHSingleConfig } from '../types';
 
 /**
  * Creates an exec function from a connected ssh2 Client instance.
@@ -24,20 +24,9 @@ import type { ExecFunction, ExecChannel } from '../types';
  * import { Client } from 'ssh2';
  * import { SQLJob, createSSH2Exec } from '@ibm/mapepire-js';
  *
- * // User manages SSH connection
  * const client = new Client();
- * await new Promise((resolve, reject) => {
- *   client.on('ready', resolve);
- *   client.on('error', reject);
- *   client.connect({
- *     host: 'your-host.com',
- *     port: 22,
- *     username: 'user',
- *     password: 'pass'
- *   });
- * });
+ * // ... connect client ...
  *
- * // Pass connected client to Mapepire
  * const job = SQLJob.withConfig({
  *   transport: 'ssh-single',
  *   sshSingle: {
@@ -49,8 +38,6 @@ import type { ExecFunction, ExecChannel } from '../types';
  * await job.connect();
  * // ... use job ...
  * await job.close();
- *
- * // User closes SSH connection
  * client.end();
  * ```
  */
@@ -62,25 +49,96 @@ export function createSSH2Exec(client: Client): ExecFunction {
           reject(err);
           return;
         }
-        
+
         const channel: ExecChannel = {
           stdin: stream.stdin,
           stdout: stream,
           stderr: stream.stderr,
-          
+
           close() {
             stream.close();
           },
-          
+
           onExit(callback) {
             stream.on('close', (code, signal) => {
               callback(code, signal);
             });
           }
         };
-        
+
         resolve(channel);
       });
     });
+  };
+}
+
+/**
+ * Creates an upload function from a connected ssh2 Client instance.
+ * Uses SFTP fastPut for efficient binary transfer.
+ *
+ * The user is responsible for:
+ * - The ssh2 Client being connected before calling this
+ * - Closing the client when done
+ *
+ * @param client - Connected ssh2 Client instance
+ * @returns UploadFunction that can be used with SSHSingleConfig.upload
+ *
+ * @example
+ * ```typescript
+ * import { Client } from 'ssh2';
+ * import { SQLJob, createSSH2Exec, createSSH2Upload } from '@ibm/mapepire-js';
+ *
+ * const job = SQLJob.withConfig({
+ *   transport: 'ssh-single',
+ *   sshSingle: {
+ *     exec: createSSH2Exec(client),
+ *     upload: createSSH2Upload(client),  // enables private install
+ *   }
+ * });
+ * ```
+ */
+export function createSSH2Upload(client: Client): UploadFunction {
+  return async function upload(localPath: string, remotePath: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      client.sftp((err, sftp) => {
+        if (err) { reject(err); return; }
+        sftp.fastPut(localPath, remotePath, (putErr) => {
+          if (putErr) { reject(putErr); } else { resolve(); }
+        });
+      });
+    });
+  };
+}
+
+/**
+ * Convenience wrapper: returns both `exec` and `upload` from a single connected ssh2 Client.
+ * Spread the result directly into `sshSingle` to enable private install with one call.
+ *
+ * @param client - Connected ssh2 Client instance
+ * @returns `{ exec, upload }` ready to spread into SSHSingleConfig
+ *
+ * @example
+ * ```typescript
+ * import { Client } from 'ssh2';
+ * import { SQLJob, createSSH2Connection } from '@ibm/mapepire-js';
+ *
+ * const client = new Client();
+ * // ... connect client ...
+ *
+ * const job = SQLJob.withConfig({
+ *   transport: 'ssh-single',
+ *   sshSingle: createSSH2Connection(client),  // private install enabled automatically
+ * });
+ *
+ * await job.connect();
+ * // ... use job ...
+ * await job.close();
+ * client.end();
+ * ```
+ */
+export function createSSH2Connection(client: Client): Pick<SSHSingleConfig, 'exec' | 'upload'> {
+  return {
+    exec:   createSSH2Exec(client),
+    upload: createSSH2Upload(client),
   };
 }

--- a/src/transports/sshSingleTransport.ts
+++ b/src/transports/sshSingleTransport.ts
@@ -297,17 +297,17 @@ export class SSHSingleTransport extends BaseTransport {
   }
 
   /**
-   * Establishes an SSH single connection
-   * @param server - Server connection details (not used for ssh-single, kept for interface compatibility)
-   * @param options - SSH single transport options
-   */
-  /**
    * Exposes the remote command used to launch the server (useful for testing/debugging).
    */
   getRemoteCommand(): string | undefined {
     return this.remoteCommand;
   }
 
+  /**
+   * Establishes an SSH single connection.
+   * @param server - Server connection details (not used for ssh-single, kept for interface compatibility)
+   * @param options - SSH single transport options
+   */
   async connect(server: DaemonServer, options: SSHSingleTransportOptions = {}): Promise<void> {
     if (!options.exec) {
       throw new Error('SSH single transport requires an exec function in sshSingle config');
@@ -322,7 +322,10 @@ export class SSHSingleTransport extends BaseTransport {
     let resolvedServerPath = options.serverPath;
 
     if (!resolvedServerPath && options.upload) {
-      // Resolve the local bundled JAR path (sits next to the compiled dist output)
+      // Resolve the local bundled JAR path (sits next to the compiled dist output).
+      // Note: __dirname is only available in CJS. This package is compiled as CJS
+      // (see tsconfig "module": "commonjs"), so this is safe. If ESM support is
+      // ever added, replace with: new URL('../../dist', import.meta.url).pathname
       const localJarPath = path.join(__dirname, '..', '..', 'dist', SERVER_VERSION_FILE);
 
       resolvedServerPath = await ensureServerInstalled({

--- a/src/transports/sshSingleTransport.ts
+++ b/src/transports/sshSingleTransport.ts
@@ -3,9 +3,12 @@
  * Library-agnostic transport that uses an exec function to launch mapepire-server in single mode
  */
 
+import path from "path";
 import { BaseTransport, TransportOptions } from "../transport";
 import { DaemonServer, ServerRequest, ServerResponse, SSHSingleConfig, ExecChannel } from "../types";
 import { LineBuffer } from "./lineBuffer";
+import { ensureServerInstalled } from "./serverInstaller";
+import { VERSION, SERVER_VERSION_FILE, JAR_SHA256 } from "../serverVersion";
 
 /**
  * Connection states for SSH single transport
@@ -34,7 +37,7 @@ export class SSHSingleTransport extends BaseTransport {
   private channel: ExecChannel | undefined;
   private lineBuffer: LineBuffer = new LineBuffer();
   private stderrBuffer: string = '';
-  private remoteCommand: string | undefined;
+  protected remoteCommand: string | undefined;
   private state: ConnectionState = ConnectionState.IDLE;
   private startupTimer: NodeJS.Timeout | undefined;
   private pendingHandshake: { resolve: () => void; reject: (err: Error) => void } | undefined;
@@ -298,15 +301,42 @@ export class SSHSingleTransport extends BaseTransport {
    * @param server - Server connection details (not used for ssh-single, kept for interface compatibility)
    * @param options - SSH single transport options
    */
+  /**
+   * Exposes the remote command used to launch the server (useful for testing/debugging).
+   */
+  getRemoteCommand(): string | undefined {
+    return this.remoteCommand;
+  }
+
   async connect(server: DaemonServer, options: SSHSingleTransportOptions = {}): Promise<void> {
     if (!options.exec) {
       throw new Error('SSH single transport requires an exec function in sshSingle config');
     }
 
-    const DEFAULT_SERVER_PATH = '/opt/mapepire/lib/mapepire/mapepire-server.jar';
-    const serverPath = options.serverPath || DEFAULT_SERVER_PATH;
-
     this.setState(ConnectionState.CONNECTING);
+
+    // --- Private install ---------------------------------------------------
+    // When serverPath is NOT explicitly provided AND an upload function IS provided,
+    // automatically ensure the bundled JAR is installed on the remote system
+    // at $HOME/.mapepire/ before launching.
+    let resolvedServerPath = options.serverPath;
+
+    if (!resolvedServerPath && options.upload) {
+      // Resolve the local bundled JAR path (sits next to the compiled dist output)
+      const localJarPath = path.join(__dirname, '..', '..', 'dist', SERVER_VERSION_FILE);
+
+      resolvedServerPath = await ensureServerInstalled({
+        exec: options.exec,
+        upload: options.upload,
+        localJarPath,
+        version: VERSION,
+        jarSha256: JAR_SHA256,
+        remoteInstallDir: options.privateInstallDir,
+      });
+    }
+
+    const DEFAULT_SERVER_PATH = '/opt/mapepire/lib/mapepire/mapepire-server.jar';
+    const serverPath = resolvedServerPath || DEFAULT_SERVER_PATH;
 
     const config: SSHSingleConfig = {
       exec: options.exec,

--- a/src/transports/sshSingleTransport.ts
+++ b/src/transports/sshSingleTransport.ts
@@ -41,6 +41,7 @@ export class SSHSingleTransport extends BaseTransport {
   private state: ConnectionState = ConnectionState.IDLE;
   private startupTimer: NodeJS.Timeout | undefined;
   private pendingHandshake: { resolve: () => void; reject: (err: Error) => void } | undefined;
+  private teardown: (() => void) | undefined;
 
   /**
    * Check if debug logging is enabled
@@ -341,6 +342,9 @@ export class SSHSingleTransport extends BaseTransport {
     const DEFAULT_SERVER_PATH = '/opt/mapepire/lib/mapepire/mapepire-server.jar';
     const serverPath = resolvedServerPath || DEFAULT_SERVER_PATH;
 
+    // Store teardown so close() can end the internally-owned SSH client (if any).
+    this.teardown = options.teardown;
+
     const config: SSHSingleConfig = {
       exec: options.exec,
       serverPath: serverPath,
@@ -437,6 +441,13 @@ export class SSHSingleTransport extends BaseTransport {
     this.connected = false;
     this.setState(ConnectionState.CLOSED);
     this.debugLog('connection closed');
+
+    // If this transport owns the SSH client (created via SQLJob.ssh2/nodeSSH),
+    // tear it down now that the channel is fully closed.
+    if (this.teardown) {
+      this.teardown();
+      this.teardown = undefined;
+    }
   }
 
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,13 @@ export interface ExecChannel {
 export type ExecFunction = (command: string) => Promise<ExecChannel>;
 
 /**
+ * Upload function type for SSH single transport private install.
+ * Transfers a local file to a remote path over SFTP/SCP.
+ * The caller is responsible for providing this — use createSSH2Upload() or createNodeSSHUpload().
+ */
+export type UploadFunction = (localPath: string, remotePath: string) => Promise<void>;
+
+/**
  * Configuration for SSH single transport
  * Uses library-agnostic exec function instead of SSH credentials
  */
@@ -85,6 +92,21 @@ export interface SSHSingleConfig {
   
   /** Request timeout in milliseconds (default: 30000) */
   requestTimeout?: number;
+
+  /**
+   * Upload function for private install (from createSSH2Upload or createNodeSSHUpload).
+   * When provided and serverPath is not set, mapepire-js will automatically check
+   * whether the correct JAR version exists at $HOME/.mapepire on the remote system,
+   * upload it if absent or outdated, and launch from there.
+   */
+  upload?: UploadFunction;
+
+  /**
+   * Override the remote install directory for private install.
+   * Defaults to $HOME/.mapepire on the remote IBM i system.
+   * Only used when upload is provided and serverPath is not set.
+   */
+  privateInstallDir?: string;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,6 +107,13 @@ export interface SSHSingleConfig {
    * Only used when upload is provided and serverPath is not set.
    */
   privateInstallDir?: string;
+
+  /**
+   * Optional teardown callback invoked automatically after the transport closes.
+   * Set by SQLJob.ssh2() / SQLJob.nodeSSH() to end the internally-owned SSH client.
+   * Not needed when you manage the SSH client yourself.
+   */
+  teardown?: () => void;
 }
 
 /**

--- a/test/serverInstaller.test.ts
+++ b/test/serverInstaller.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ensureServerInstalled, ServerInstallerOptions } from '../src/transports/serverInstaller';
+import { ExecChannel, ExecFunction, UploadFunction } from '../src/types';
+import { Readable, Writable } from 'stream';
+
+// ---------------------------------------------------------------------------
+// Helpers to build mock ExecChannels for simple command output
+// ---------------------------------------------------------------------------
+
+function makeExecChannel(stdout: string, exitCode = 0): ExecChannel {
+  const stdoutStream = new Readable({ read() {} });
+  const stderrStream = new Readable({ read() {} });
+  const stdinStream  = new Writable({ write(_c, _e, cb) { cb(); } });
+
+  let exitCb: ((code: number | null, signal?: string) => void) | undefined;
+
+  // Push data and emit exit in sequence: data first, then a second tick for exit.
+  // This ensures the 'data' event fires before runCommand's onExit resolves.
+  process.nextTick(() => {
+    if (stdout) stdoutStream.push(Buffer.from(stdout));
+    stdoutStream.push(null);
+    stderrStream.push(null);
+    // Give the stream a chance to flush data listeners before firing exit
+    process.nextTick(() => exitCb?.(exitCode));
+  });
+
+  return {
+    stdin: stdinStream,
+    stdout: stdoutStream,
+    stderr: stderrStream,
+    close: vi.fn(),
+    onExit(cb) { exitCb = cb; },
+  };
+}
+
+/** Build an ExecFunction that dispatches different responses based on command substring */
+function makeExec(routes: Array<{ match: string | RegExp; stdout: string; code?: number }>): ExecFunction {
+  return vi.fn(async (command: string) => {
+    for (const route of routes) {
+      const hit = typeof route.match === 'string'
+        ? command.includes(route.match)
+        : route.match.test(command);
+      if (hit) return makeExecChannel(route.stdout, route.code ?? 0);
+    }
+    // Default: success with empty output
+    return makeExecChannel('');
+  }) as unknown as ExecFunction;
+}
+
+// ---------------------------------------------------------------------------
+// Common options factory
+// ---------------------------------------------------------------------------
+
+const BUNDLED_VERSION = '2.3.5';
+const BUNDLED_SHA256  = 'abc123def456abc123def456abc123def456abc123def456abc123def456abc1';
+const LOCAL_JAR       = '/local/dist/mapepire-server-2.3.5.jar';
+const HOME_DIR        = '/home/testuser';
+const INSTALL_DIR     = `${HOME_DIR}/.mapepire`;
+const REMOTE_JAR      = `${INSTALL_DIR}/mapepire-server-${BUNDLED_VERSION}.jar`;
+
+function makeUpload(): UploadFunction {
+  return vi.fn().mockResolvedValue(undefined) as unknown as UploadFunction;
+}
+
+function makeOpenSslRoute(sha256 = BUNDLED_SHA256): { match: string; stdout: string } {
+  return { match: 'openssl dgst -sha256', stdout: `SHA256(${REMOTE_JAR})= ${sha256}` };
+}
+
+function baseOptions(exec: ExecFunction, upload: UploadFunction): ServerInstallerOptions {
+  return {
+    exec,
+    upload,
+    localJarPath: LOCAL_JAR,
+    version: BUNDLED_VERSION,
+    jarSha256: BUNDLED_SHA256,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ensureServerInstalled', () => {
+
+  it('Test A: JAR found at correct version — upload NOT called, SHA256 verified, path returned', async () => {
+    const upload = makeUpload();
+    const exec = makeExec([
+      { match: 'echo $HOME',      stdout: HOME_DIR },
+      { match: '/QOpenSys/usr/bin/find', stdout: REMOTE_JAR },
+      makeOpenSslRoute(),
+    ]);
+
+    const result = await ensureServerInstalled(baseOptions(exec, upload));
+
+    expect(result).toBe(REMOTE_JAR);
+    expect(upload).not.toHaveBeenCalled();
+  });
+
+  it('Test B: No JAR found — mkdir called, upload called, chmod called, SHA256 verified', async () => {
+    const upload = makeUpload();
+    const exec = makeExec([
+      { match: 'echo $HOME',            stdout: HOME_DIR },
+      { match: '/QOpenSys/usr/bin/find', stdout: '' },   // nothing found
+      { match: 'mkdir -p',              stdout: '' },
+      { match: 'chmod +x',             stdout: '' },
+      makeOpenSslRoute(),
+    ]) as ReturnType<typeof vi.fn> & ExecFunction;
+
+    const result = await ensureServerInstalled(baseOptions(exec, upload));
+
+    expect(result).toBe(REMOTE_JAR);
+    expect(upload).toHaveBeenCalledOnce();
+    expect(upload).toHaveBeenCalledWith(LOCAL_JAR, REMOTE_JAR);
+
+    const calls = (exec as ReturnType<typeof vi.fn>).mock.calls.map((c: any[]) => c[0] as string);
+    expect(calls.some(c => c.includes('mkdir -p'))).toBe(true);
+    expect(calls.some(c => c.includes('chmod +x'))).toBe(true);
+  });
+
+  it('Test C: Single outdated JAR found — upload triggered', async () => {
+    const upload = makeUpload();
+    const oldJarPath = `${INSTALL_DIR}/mapepire-server-2.2.0.jar`;
+    const exec = makeExec([
+      { match: 'echo $HOME',            stdout: HOME_DIR },
+      { match: '/QOpenSys/usr/bin/find', stdout: oldJarPath },
+      { match: 'mkdir -p',              stdout: '' },
+      { match: 'chmod +x',             stdout: '' },
+      makeOpenSslRoute(),
+    ]);
+
+    const result = await ensureServerInstalled(baseOptions(exec, upload));
+
+    expect(result).toBe(REMOTE_JAR);
+    expect(upload).toHaveBeenCalledOnce();
+  });
+
+  it('Test D: Mixed versions — one outdated, one current — upload NOT triggered', async () => {
+    const upload = makeUpload();
+    const oldJar     = `${INSTALL_DIR}/mapepire-server-2.2.0.jar`;
+    const currentJar = `${INSTALL_DIR}/mapepire-server-2.3.5.jar`;
+    const exec = makeExec([
+      { match: 'echo $HOME',            stdout: HOME_DIR },
+      { match: '/QOpenSys/usr/bin/find', stdout: `${oldJar}\n${currentJar}` },
+      makeOpenSslRoute(),
+    ]);
+
+    const result = await ensureServerInstalled(baseOptions(exec, upload));
+
+    expect(result).toBe(REMOTE_JAR);
+    expect(upload).not.toHaveBeenCalled();
+  });
+
+  it('Test E: Upload function throws — error propagated', async () => {
+    const upload = vi.fn().mockRejectedValue(new Error('SFTP transfer failed')) as unknown as UploadFunction;
+    const exec = makeExec([
+      { match: 'echo $HOME',            stdout: HOME_DIR },
+      { match: '/QOpenSys/usr/bin/find', stdout: '' },
+      { match: 'mkdir -p',              stdout: '' },
+    ]);
+
+    await expect(ensureServerInstalled(baseOptions(exec, upload)))
+      .rejects.toThrow('SFTP transfer failed');
+  });
+
+  it('Test F: SHA256 mismatch after upload — tamper error thrown', async () => {
+    const upload = makeUpload();
+    const exec = makeExec([
+      { match: 'echo $HOME',            stdout: HOME_DIR },
+      { match: '/QOpenSys/usr/bin/find', stdout: '' },
+      { match: 'mkdir -p',              stdout: '' },
+      { match: 'chmod +x',             stdout: '' },
+      { match: 'openssl dgst -sha256',  stdout: `SHA256(${REMOTE_JAR})= deadbeef` },
+    ]);
+
+    await expect(ensureServerInstalled(baseOptions(exec, upload)))
+      .rejects.toThrow(/SHA-256 mismatch/);
+  });
+
+  it('Test G: echo $HOME returns empty — error propagated', async () => {
+    const upload = makeUpload();
+    const exec = makeExec([
+      { match: 'echo $HOME', stdout: '' },
+    ]);
+
+    await expect(ensureServerInstalled(baseOptions(exec, upload)))
+      .rejects.toThrow(/Could not resolve \$HOME/);
+  });
+
+  it('Test H: newer version already present — upload NOT triggered, newer path returned, SHA256 NOT called', async () => {
+    const upload = makeUpload();
+    const newerJar = `${INSTALL_DIR}/mapepire-server-3.0.0.jar`;
+    const exec = makeExec([
+      { match: 'echo $HOME',            stdout: HOME_DIR },
+      { match: '/QOpenSys/usr/bin/find', stdout: newerJar },
+      // No openssl route — SHA-256 must NOT be called for a pre-existing remote JAR
+    ]) as ReturnType<typeof vi.fn> & ExecFunction;
+
+    const result = await ensureServerInstalled(baseOptions(exec, upload));
+
+    expect(result).toBe(newerJar);
+    expect(upload).not.toHaveBeenCalled();
+    const calls = (exec as ReturnType<typeof vi.fn>).mock.calls.map((c: any[]) => c[0] as string);
+    expect(calls.some(c => c.includes('openssl'))).toBe(false);
+  });
+
+  it('Test I: custom remoteInstallDir is respected', async () => {
+    const customDir = '/custom/install/dir';
+    const customJar = `${customDir}/mapepire-server-${BUNDLED_VERSION}.jar`;
+    const upload = makeUpload();
+    const exec = makeExec([
+      { match: 'echo $HOME',            stdout: HOME_DIR },
+      { match: '/QOpenSys/usr/bin/find', stdout: '' },
+      { match: 'mkdir -p',              stdout: '' },
+      { match: 'chmod +x',             stdout: '' },
+      { match: 'openssl dgst -sha256',  stdout: `SHA256(${customJar})= ${BUNDLED_SHA256}` },
+    ]);
+
+    const result = await ensureServerInstalled({
+      ...baseOptions(exec, upload),
+      remoteInstallDir: customDir,
+    });
+
+    expect(result).toBe(customJar);
+    expect(upload).toHaveBeenCalledWith(LOCAL_JAR, customJar);
+  });
+
+  it('Test J: empty jarSha256 — SHA256 verification skipped', async () => {
+    const upload = makeUpload();
+    const exec = makeExec([
+      { match: 'echo $HOME',            stdout: HOME_DIR },
+      { match: '/QOpenSys/usr/bin/find', stdout: '' },
+      { match: 'mkdir -p',              stdout: '' },
+      { match: 'chmod +x',             stdout: '' },
+      // No openssl route — should not be called
+    ]);
+
+    const result = await ensureServerInstalled({
+      ...baseOptions(exec, upload),
+      jarSha256: '',
+    });
+
+    expect(result).toBe(REMOTE_JAR);
+    const calls = (exec as ReturnType<typeof vi.fn>).mock.calls.map((c: any[]) => c[0] as string);
+    expect(calls.some(c => c.includes('openssl'))).toBe(false);
+  });
+});

--- a/test/sshHelpers.test.ts
+++ b/test/sshHelpers.test.ts
@@ -43,6 +43,7 @@ function makeFakeSsh2Client(stdout = '', stderr = '', exitCode = 0) {
     sftp: vi.fn((cb: (err: null, sftp: any) => void) => {
       cb(null, {
         fastPut: vi.fn((_local: string, _remote: string, done: (err: null) => void) => done(null)),
+        end: vi.fn(),
       });
     }),
     _stream: stream,
@@ -185,6 +186,7 @@ describe('createSSH2Upload – unit', () => {
           fastPut: vi.fn((_l: string, _r: string, done: (err: Error) => void) =>
             done(new Error('fastPut failed'))
           ),
+          end: vi.fn(),
         });
       }),
     };

--- a/test/sshHelpers.test.ts
+++ b/test/sshHelpers.test.ts
@@ -1,25 +1,319 @@
 import 'dotenv/config';
-import { describe, test, expect, beforeAll, afterAll } from 'vitest';
-import { SQLJob, createSSH2Exec, createNodeSSHExec } from '../src';
+import { describe, test, expect, vi, beforeAll, afterAll } from 'vitest';
+import { Readable, Writable } from 'stream';
+import { SQLJob, createSSH2Exec, createSSH2Upload, createNodeSSHExec, createNodeSSHUpload } from '../src';
+import type { ExecChannel } from '../src/types';
 
-/**
- * SSH Helper Tests
- *
- * These tests verify that the SSH helper utilities (createSSH2Exec and createNodeSSHExec)
- * correctly map SSH client objects to ExecFunction interfaces that work with Mapepire.
- *
- * Test Environment Variables:
- * - SSH_TEST_HOST: SSH hostname (required)
- * - SSH_TEST_PORT: SSH port (default: 22)
- * - SSH_TEST_USER: SSH username (required)
- * - SSH_TEST_PASS: SSH password (required)
- * - SSH_TEST_SERVER_PATH: Path to mapepire-server.jar (required)
- * - SSH_TEST_JAVA_PATH: Path to java executable (optional, defaults to 'java')
- *
- * Note: ssh2 and node-ssh are optional dependencies. Tests are skipped if not installed.
- */
+// ===========================================================================
+// Fake SSH stream / client factories — no real SSH needed
+// ===========================================================================
 
-// Optional imports — ssh2 and node-ssh are only required if using SSH single mode
+/** Build a fake ssh2-style exec stream that emits stdout, stderr, and close. */
+function makeFakeStream(stdout = '', stderr = '', exitCode = 0) {
+  const stdoutReadable = new Readable({ read() {} });
+  const stderrReadable = new Readable({ read() {} });
+  const stdinWritable = new Writable({ write(_c, _e, cb) { cb(); } });
+
+  // Attach .stdin so callers can write to it
+  const stream = Object.assign(stdoutReadable, {
+    stdin: stdinWritable,
+    stderr: stderrReadable,
+    close: vi.fn(),
+  }) as any;
+
+  // Emit data + close on next tick so handlers can be attached first
+  process.nextTick(() => {
+    if (stdout) stdoutReadable.push(Buffer.from(stdout));
+    stdoutReadable.push(null);
+    if (stderr) stderrReadable.push(Buffer.from(stderr));
+    stderrReadable.push(null);
+    stdoutReadable.emit('close', exitCode, null);
+  });
+
+  return stream;
+}
+
+/** Build a minimal fake ssh2 Client. */
+function makeFakeSsh2Client(stdout = '', stderr = '', exitCode = 0) {
+  const stream = makeFakeStream(stdout, stderr, exitCode);
+  return {
+    exec: vi.fn((_cmd: string, cb: (err: null, stream: any) => void) => {
+      cb(null, stream);
+    }),
+    sftp: vi.fn((cb: (err: null, sftp: any) => void) => {
+      cb(null, {
+        fastPut: vi.fn((_local: string, _remote: string, done: (err: null) => void) => done(null)),
+      });
+    }),
+    _stream: stream,
+  };
+}
+
+/** Build a minimal fake NodeSSH instance (mirrors the interface used by createNodeSSHExec). */
+function makeFakeNodeSSH(stdout = '', stderr = '', exitCode = 0) {
+  const stream = makeFakeStream(stdout, stderr, exitCode);
+  const fakeClient = {
+    exec: vi.fn((_cmd: string, cb: (err: null, stream: any) => void) => cb(null, stream)),
+  };
+  return {
+    connection: fakeClient,
+    putFile: vi.fn().mockResolvedValue(undefined),
+    _stream: stream,
+    _client: fakeClient,
+  } as any;
+}
+
+// ===========================================================================
+// Unit tests — createSSH2Exec (no real SSH)
+// ===========================================================================
+
+describe('createSSH2Exec – unit', () => {
+  test('returns a function', () => {
+    const client = makeFakeSsh2Client();
+    const exec = createSSH2Exec(client as any);
+    expect(typeof exec).toBe('function');
+  });
+
+  test('returned function calls client.exec with the given command', async () => {
+    const client = makeFakeSsh2Client();
+    const exec = createSSH2Exec(client as any);
+    await exec('echo hello').catch(() => {}); // channel may emit exit — ignore
+    expect(client.exec).toHaveBeenCalledWith('echo hello', expect.any(Function));
+  });
+
+  test('returned ExecChannel exposes stdin, stdout, stderr', async () => {
+    const client = makeFakeSsh2Client();
+    const exec = createSSH2Exec(client as any);
+    const channel: ExecChannel = await exec('ls');
+    expect(channel.stdin).toBeDefined();
+    expect(channel.stdout).toBeDefined();
+    expect(channel.stderr).toBeDefined();
+  });
+
+  test('ExecChannel.close() delegates to stream.close()', async () => {
+    const client = makeFakeSsh2Client();
+    const exec = createSSH2Exec(client as any);
+    const channel = await exec('ls');
+    channel.close();
+    expect(client._stream.close).toHaveBeenCalledOnce();
+  });
+
+  test('ExecChannel.onExit fires when stream emits close', async () => {
+    const client = makeFakeSsh2Client('', '', 0);
+    const exec = createSSH2Exec(client as any);
+    const channel = await exec('ls');
+
+    const exitSpy = vi.fn();
+    channel.onExit(exitSpy);
+
+    // The fake stream emits close on nextTick — wait for it
+    await new Promise<void>(resolve => setTimeout(resolve, 20));
+    expect(exitSpy).toHaveBeenCalledWith(0, null);
+  });
+
+  test('ExecChannel.onExit receives non-zero exit code', async () => {
+    const client = makeFakeSsh2Client('', 'error', 1);
+    const exec = createSSH2Exec(client as any);
+    const channel = await exec('bad-cmd');
+
+    const exitSpy = vi.fn();
+    channel.onExit(exitSpy);
+
+    await new Promise<void>(resolve => setTimeout(resolve, 20));
+    expect(exitSpy).toHaveBeenCalledWith(1, null);
+  });
+
+  test('stdout data flows through ExecChannel.stdout', async () => {
+    const client = makeFakeSsh2Client('hello world');
+    const exec = createSSH2Exec(client as any);
+    const channel = await exec('echo hello world');
+
+    const chunks: string[] = [];
+    channel.stdout.on('data', (d: Buffer) => chunks.push(d.toString()));
+
+    await new Promise<void>(resolve => setTimeout(resolve, 20));
+    expect(chunks.join('')).toBe('hello world');
+  });
+
+  test('rejects when client.exec yields an error', async () => {
+    const client = {
+      exec: vi.fn((_cmd: string, cb: (err: Error, stream: null) => void) => {
+        cb(new Error('exec failed'), null);
+      }),
+    };
+    const exec = createSSH2Exec(client as any);
+    await expect(exec('ls')).rejects.toThrow('exec failed');
+  });
+});
+
+// ===========================================================================
+// Unit tests — createSSH2Upload (no real SSH)
+// ===========================================================================
+
+describe('createSSH2Upload – unit', () => {
+  test('returns a function', () => {
+    const client = makeFakeSsh2Client();
+    const upload = createSSH2Upload(client as any);
+    expect(typeof upload).toBe('function');
+  });
+
+  test('calls sftp.fastPut with correct local and remote paths', async () => {
+    const client = makeFakeSsh2Client();
+    const upload = createSSH2Upload(client as any);
+    await upload('/local/mapepire.jar', '/remote/.mapepire/mapepire.jar');
+    expect(client.sftp).toHaveBeenCalledOnce();
+  });
+
+  test('resolves on success', async () => {
+    const client = makeFakeSsh2Client();
+    const upload = createSSH2Upload(client as any);
+    await expect(upload('/a', '/b')).resolves.toBeUndefined();
+  });
+
+  test('rejects when sftp() yields an error', async () => {
+    const client = {
+      sftp: vi.fn((cb: (err: Error, sftp: null) => void) => cb(new Error('sftp open failed'), null)),
+    };
+    const upload = createSSH2Upload(client as any);
+    await expect(upload('/a', '/b')).rejects.toThrow('sftp open failed');
+  });
+
+  test('rejects when fastPut() yields an error', async () => {
+    const client = {
+      sftp: vi.fn((cb: (err: null, sftp: any) => void) => {
+        cb(null, {
+          fastPut: vi.fn((_l: string, _r: string, done: (err: Error) => void) =>
+            done(new Error('fastPut failed'))
+          ),
+        });
+      }),
+    };
+    const upload = createSSH2Upload(client as any);
+    await expect(upload('/a', '/b')).rejects.toThrow('fastPut failed');
+  });
+});
+
+// ===========================================================================
+// Unit tests — createNodeSSHExec (no real SSH)
+// ===========================================================================
+
+describe('createNodeSSHExec – unit', () => {
+  test('returns a function when connection is present', () => {
+    const ssh = makeFakeNodeSSH();
+    const exec = createNodeSSHExec(ssh);
+    expect(typeof exec).toBe('function');
+  });
+
+  test('throws immediately when NodeSSH instance is not connected', () => {
+    const ssh = { connection: null } as any;
+    expect(() => createNodeSSHExec(ssh)).toThrow('NodeSSH instance is not connected');
+  });
+
+  test('returned function calls connection.exec with the given command', async () => {
+    const ssh = makeFakeNodeSSH();
+    const exec = createNodeSSHExec(ssh);
+    await exec('echo hi').catch(() => {});
+    expect(ssh._client.exec).toHaveBeenCalledWith('echo hi', expect.any(Function));
+  });
+
+  test('returned ExecChannel exposes stdin, stdout, stderr', async () => {
+    const ssh = makeFakeNodeSSH();
+    const exec = createNodeSSHExec(ssh);
+    const channel = await exec('ls');
+    expect(channel.stdin).toBeDefined();
+    expect(channel.stdout).toBeDefined();
+    expect(channel.stderr).toBeDefined();
+  });
+
+  test('ExecChannel.close() delegates to stream.close()', async () => {
+    const ssh = makeFakeNodeSSH();
+    const exec = createNodeSSHExec(ssh);
+    const channel = await exec('ls');
+    channel.close();
+    expect(ssh._stream.close).toHaveBeenCalledOnce();
+  });
+
+  test('ExecChannel.onExit fires when stream emits close', async () => {
+    const ssh = makeFakeNodeSSH('', '', 0);
+    const exec = createNodeSSHExec(ssh);
+    const channel = await exec('ls');
+
+    const exitSpy = vi.fn();
+    channel.onExit(exitSpy);
+
+    await new Promise<void>(resolve => setTimeout(resolve, 20));
+    expect(exitSpy).toHaveBeenCalledWith(0, null);
+  });
+
+  test('stdout data flows through ExecChannel.stdout', async () => {
+    const ssh = makeFakeNodeSSH('result-data');
+    const exec = createNodeSSHExec(ssh);
+    const channel = await exec('query');
+
+    const chunks: string[] = [];
+    channel.stdout.on('data', (d: Buffer) => chunks.push(d.toString()));
+
+    await new Promise<void>(resolve => setTimeout(resolve, 20));
+    expect(chunks.join('')).toBe('result-data');
+  });
+
+  test('rejects when connection.exec yields an error', async () => {
+    const ssh = {
+      connection: {
+        exec: vi.fn((_cmd: string, cb: (err: Error, stream: null) => void) => {
+          cb(new Error('exec rejected'), null);
+        }),
+      },
+    } as any;
+    const exec = createNodeSSHExec(ssh);
+    await expect(exec('ls')).rejects.toThrow('exec rejected');
+  });
+
+  test('rejects if connection disappears between create and call', async () => {
+    const ssh = makeFakeNodeSSH();
+    const exec = createNodeSSHExec(ssh);
+    // Sever the connection after the exec function is created
+    ssh.connection = null;
+    await expect(exec('ls')).rejects.toThrow('NodeSSH instance is not connected');
+  });
+});
+
+// ===========================================================================
+// Unit tests — createNodeSSHUpload (no real SSH)
+// ===========================================================================
+
+describe('createNodeSSHUpload – unit', () => {
+  test('returns a function', () => {
+    const ssh = makeFakeNodeSSH();
+    const upload = createNodeSSHUpload(ssh);
+    expect(typeof upload).toBe('function');
+  });
+
+  test('calls ssh.putFile with correct paths', async () => {
+    const ssh = makeFakeNodeSSH();
+    const upload = createNodeSSHUpload(ssh);
+    await upload('/local/jar', '/remote/jar');
+    expect(ssh.putFile).toHaveBeenCalledWith('/local/jar', '/remote/jar');
+  });
+
+  test('resolves on success', async () => {
+    const ssh = makeFakeNodeSSH();
+    const upload = createNodeSSHUpload(ssh);
+    await expect(upload('/a', '/b')).resolves.toBeUndefined();
+  });
+
+  test('rejects when putFile throws', async () => {
+    const ssh = makeFakeNodeSSH();
+    ssh.putFile = vi.fn().mockRejectedValue(new Error('putFile error'));
+    const upload = createNodeSSHUpload(ssh);
+    await expect(upload('/a', '/b')).rejects.toThrow('putFile error');
+  });
+});
+
+// ===========================================================================
+// Optional imports for integration tests
+// ===========================================================================
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let Client: any;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -27,17 +321,13 @@ let NodeSSH: any;
 
 try {
   Client = require('ssh2').Client;
-} catch (e) {
-  // ssh2 not installed — tests will be skipped
-}
+} catch (e) { /* ssh2 not installed */ }
 
 try {
   NodeSSH = require('node-ssh').NodeSSH;
-} catch (e) {
-  // node-ssh not installed — tests will be skipped
-}
+} catch (e) { /* node-ssh not installed */ }
 
-// SSH credentials from environment
+// Integration tests require: live host env vars AND optional SSH libs
 const SSH_CREDS = {
   host: process.env.SSH_TEST_HOST || 'localhost',
   port: Number(process.env.SSH_TEST_PORT) || 22,
@@ -46,55 +336,48 @@ const SSH_CREDS = {
 };
 
 const SERVER_CONFIG = {
-  serverPath: process.env.SSH_TEST_SERVER_PATH || 'mapepire-server.jar',
-  javaPath: process.env.SSH_TEST_JAVA_PATH || 'java',
+  serverPath: process.env.SSH_TEST_SERVER_PATH || undefined,
+  javaPath: process.env.SSH_TEST_JAVA_PATH || undefined,
   startupTimeout: 30000,
 };
 
-// Skip tests if SSH credentials are not configured OR if optional dependencies are missing
-const shouldSkip = !process.env.SSH_TEST_HOST || !process.env.SSH_TEST_USER || !Client || !NodeSSH;
+// Integration tests are opt-in: set SSH_TEST_INTEGRATION=1 to enable.
+// This prevents accidental runs on dev machines where the remote JAR may not exist yet.
+const shouldSkip =
+  process.env.SSH_TEST_INTEGRATION !== '1' ||
+  !process.env.SSH_TEST_HOST ||
+  !process.env.SSH_TEST_USER ||
+  !process.env.SSH_TEST_SERVER_PATH ||
+  !Client ||
+  !NodeSSH;
 
-describe('SSH Helper - createSSH2Exec', () => {
+// ===========================================================================
+// Integration tests — createSSH2Exec (real IBM i, skipped when not configured)
+// ===========================================================================
+
+describe('SSH Helper - createSSH2Exec (integration)', () => {
   if (shouldSkip) {
-    test.skip('SSH tests skipped - set SSH_TEST_HOST and SSH_TEST_USER to enable', () => {});
+    test.skip(
+      'SSH integration tests skipped — set SSH_TEST_HOST, SSH_TEST_USER, SSH_TEST_SERVER_PATH to enable',
+      () => {}
+    );
     return;
   }
 
-  let sshClient: Client | null = null;
+  let sshClient: typeof Client | null = null;
 
   afterAll(() => {
-    if (sshClient) {
-      sshClient.end();
-      sshClient = null;
-    }
+    if (sshClient) { sshClient.end(); sshClient = null; }
   });
 
-  test('should create exec function from connected ssh2 client', async () => {
-    // Connect SSH client
+  test('should successfully connect to database using ssh single mode (ssh2)', async () => {
     sshClient = new Client();
     await new Promise<void>((resolve, reject) => {
       sshClient!.on('ready', () => resolve());
-      sshClient!.on('error', (err) => reject(err));
+      sshClient!.on('error', (err: Error) => reject(err));
       sshClient!.connect(SSH_CREDS);
     });
 
-    // Create exec function using helper
-    const exec = createSSH2Exec(sshClient);
-
-    expect(exec).toBeDefined();
-    expect(typeof exec).toBe('function');
-  });
-
-  test('should successfully connect to database using ssh single mode(ssh2)', async () => {
-    // Connect SSH client
-    sshClient = new Client();
-    await new Promise<void>((resolve, reject) => {
-      sshClient!.on('ready', () => resolve());
-      sshClient!.on('error', (err) => reject(err));
-      sshClient!.connect(SSH_CREDS);
-    });
-
-    // Create SQLJob with helper
     const job = SQLJob.withConfig({
       transport: 'ssh-single',
       sshSingle: {
@@ -119,12 +402,11 @@ describe('SSH Helper - createSSH2Exec', () => {
     }
   });
 
-  test('should execute SQL query successfully with ssh single mode(ssh2)', async () => {
-    // Connect SSH client
+  test('should execute SQL query successfully with ssh single mode (ssh2)', async () => {
     sshClient = new Client();
     await new Promise<void>((resolve, reject) => {
       sshClient!.on('ready', () => resolve());
-      sshClient!.on('error', (err) => reject(err));
+      sshClient!.on('error', (err: Error) => reject(err));
       sshClient!.connect(SSH_CREDS);
     });
 
@@ -139,16 +421,12 @@ describe('SSH Helper - createSSH2Exec', () => {
 
     try {
       await job.connect();
-
-      // Execute a simple query
       const result = await job.execute('SELECT * FROM QIWS.QCUSTCDT FETCH FIRST 5 ROWS ONLY');
-      
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
-      expect(result.data).toBeDefined();
       expect(Array.isArray(result.data)).toBe(true);
-      expect(result.data.length).toBeGreaterThan(0);
-      expect(result.data.length).toBeLessThanOrEqual(5);
+      expect(result.data!.length).toBeGreaterThan(0);
+      expect(result.data!.length).toBeLessThanOrEqual(5);
     } finally {
       await job.close();
       sshClient.end();
@@ -156,11 +434,11 @@ describe('SSH Helper - createSSH2Exec', () => {
     }
   });
 
-  test('should get server version with ssh single mode(ssh2)', async () => {
+  test('should handle invalid server path gracefully', async () => {
     sshClient = new Client();
     await new Promise<void>((resolve, reject) => {
       sshClient!.on('ready', () => resolve());
-      sshClient!.on('error', (err) => reject(err));
+      sshClient!.on('error', (err: Error) => reject(err));
       sshClient!.connect(SSH_CREDS);
     });
 
@@ -168,107 +446,45 @@ describe('SSH Helper - createSSH2Exec', () => {
       transport: 'ssh-single',
       sshSingle: {
         exec: createSSH2Exec(sshClient),
-        serverPath: SERVER_CONFIG.serverPath,
+        serverPath: '/invalid/path/to/nonexistent.jar',
         javaPath: SERVER_CONFIG.javaPath,
+        startupTimeout: 5000,
       },
     });
 
     try {
-      await job.connect();
-      const version = await job.getVersion();
-      
-      expect(version).toBeDefined();
-      expect(version.success).toBe(true);
-      expect(version.build_date).toBeDefined();
-      expect(version.version).toBeDefined();
+      await expect(job.connect()).rejects.toThrow();
     } finally {
-      await job.close();
-      sshClient.end();
-      sshClient = null;
-    }
-  });
-
-  test('should handle multiple queries in sequence with ssh single mode(ssh2)', async () => {
-    sshClient = new Client();
-    await new Promise<void>((resolve, reject) => {
-      sshClient!.on('ready', () => resolve());
-      sshClient!.on('error', (err) => reject(err));
-      sshClient!.connect(SSH_CREDS);
-    });
-
-    const job = SQLJob.withConfig({
-      transport: 'ssh-single',
-      sshSingle: {
-        exec: createSSH2Exec(sshClient),
-        serverPath: SERVER_CONFIG.serverPath,
-        javaPath: SERVER_CONFIG.javaPath,
-      },
-    });
-
-    try {
-      await job.connect();
-
-      // Query 1
-      const result1 = await job.execute('SELECT COUNT(*) as TOTAL FROM QIWS.QCUSTCDT');
-      expect(result1.success).toBe(true);
-      expect(result1.data).toBeDefined();
-      if (result1.data && result1.data.length > 0) {
-        expect((result1.data[0] as any).TOTAL).toBeGreaterThan(0);
-      }
-
-      // Query 2 — column label varies by JDBC naming mode, just check a row came back
-      const result2 = await job.execute('SELECT CURRENT USER FROM SYSIBM.SYSDUMMY1');
-      expect(result2.success).toBe(true);
-      expect(result2.data).toBeDefined();
-      if (result2.data && result2.data.length > 0) {
-        const firstValue = Object.values(result2.data[0] as any)[0];
-        expect(firstValue).toBeDefined();
-      }
-
-      // Query 3 - Create temp table
-      const result3 = await job.execute('CREATE TABLE QTEMP.SSH2TEST (ID INT, NAME VARCHAR(50))');
-      expect(result3.success).toBe(true);
-    } finally {
-      await job.close();
+      await job.close().catch(() => {});
       sshClient.end();
       sshClient = null;
     }
   });
 });
 
-describe('SSH Helper - createNodeSSHExec', () => {
+// ===========================================================================
+// Integration tests — createNodeSSHExec (real IBM i, skipped when not configured)
+// ===========================================================================
+
+describe('SSH Helper - createNodeSSHExec (integration)', () => {
   if (shouldSkip) {
-    test.skip('SSH tests skipped - set SSH_TEST_HOST and SSH_TEST_USER to enable', () => {});
+    test.skip(
+      'SSH integration tests skipped — set SSH_TEST_HOST, SSH_TEST_USER, SSH_TEST_SERVER_PATH to enable',
+      () => {}
+    );
     return;
   }
 
   let ssh: any = null;
 
   afterAll(() => {
-    if (ssh) {
-      ssh.dispose();
-      ssh = null;
-    }
+    if (ssh) { ssh.dispose(); ssh = null; }
   });
 
-  test('should create exec function from connected node-ssh instance', async () => {
-    // Connect node-ssh
+  test('should successfully connect to database using ssh single mode (node-ssh)', async () => {
     ssh = new NodeSSH();
     await ssh.connect(SSH_CREDS);
 
-    // Create exec function using helper
-    const exec = createNodeSSHExec(ssh);
-
-    expect(exec).toBeDefined();
-    expect(typeof exec).toBe('function');
-  });
-
-  test('should successfully connect to database using ssh single mode(node-ssh)', async () => {
-    // Connect node-ssh
-    ssh = new NodeSSH();
-    await ssh.connect(SSH_CREDS);
-
-    // Create SQLJob with helper
     const job = SQLJob.withConfig({
       transport: 'ssh-single',
       sshSingle: {
@@ -283,7 +499,6 @@ describe('SSH Helper - createNodeSSHExec', () => {
       const result = await job.connect();
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
-      expect(result.job).toBeDefined();
       expect(typeof result.job).toBe('string');
       expect(result.job.length).toBeGreaterThan(0);
     } finally {
@@ -293,8 +508,7 @@ describe('SSH Helper - createNodeSSHExec', () => {
     }
   });
 
-  test('should execute SQL query successfully with ssh single mode(node-ssh)', async () => {
-    // Connect node-ssh
+  test('should execute SQL query successfully with ssh single mode (node-ssh)', async () => {
     ssh = new NodeSSH();
     await ssh.connect(SSH_CREDS);
 
@@ -309,87 +523,11 @@ describe('SSH Helper - createNodeSSHExec', () => {
 
     try {
       await job.connect();
-
-      // Execute a simple query
       const result = await job.execute('SELECT * FROM QIWS.QCUSTCDT FETCH FIRST 3 ROWS ONLY');
-      
-      expect(result).toBeDefined();
       expect(result.success).toBe(true);
-      expect(result.data).toBeDefined();
       expect(Array.isArray(result.data)).toBe(true);
-      expect(result.data.length).toBeGreaterThan(0);
-      expect(result.data.length).toBeLessThanOrEqual(3);
-    } finally {
-      await job.close();
-      ssh.dispose();
-      ssh = null;
-    }
-  });
-
-  test('should get server version with ssh single mode(node-ssh)', async () => {
-    ssh = new NodeSSH();
-    await ssh.connect(SSH_CREDS);
-
-    const job = SQLJob.withConfig({
-      transport: 'ssh-single',
-      sshSingle: {
-        exec: createNodeSSHExec(ssh),
-        serverPath: SERVER_CONFIG.serverPath,
-        javaPath: SERVER_CONFIG.javaPath,
-      },
-    });
-
-    try {
-      await job.connect();
-      const version = await job.getVersion();
-      
-      expect(version).toBeDefined();
-      expect(version.success).toBe(true);
-      expect(version.build_date).toBeDefined();
-      expect(version.version).toBeDefined();
-    } finally {
-      await job.close();
-      ssh.dispose();
-      ssh = null;
-    }
-  });
-
-  test('should handle multiple queries in sequence with ssh single mode(node-ssh)', async () => {
-    ssh = new NodeSSH();
-    await ssh.connect(SSH_CREDS);
-
-    const job = SQLJob.withConfig({
-      transport: 'ssh-single',
-      sshSingle: {
-        exec: createNodeSSHExec(ssh),
-        serverPath: SERVER_CONFIG.serverPath,
-        javaPath: SERVER_CONFIG.javaPath,
-      },
-    });
-
-    try {
-      await job.connect();
-
-      // Query 1
-      const result1 = await job.execute('SELECT COUNT(*) as TOTAL FROM QIWS.QCUSTCDT');
-      expect(result1.success).toBe(true);
-      expect(result1.data).toBeDefined();
-      if (result1.data && result1.data.length > 0) {
-        expect((result1.data[0] as any).TOTAL).toBeGreaterThan(0);
-      }
-
-      // Query 2 — column label varies by JDBC naming mode, just check a row came back
-      const result2 = await job.execute('SELECT CURRENT TIMESTAMP FROM SYSIBM.SYSDUMMY1');
-      expect(result2.success).toBe(true);
-      expect(result2.data).toBeDefined();
-      if (result2.data && result2.data.length > 0) {
-        const firstValue = Object.values(result2.data[0] as any)[0];
-        expect(firstValue).toBeDefined();
-      }
-
-      // Query 3 - Create temp table
-      const result3 = await job.execute('CREATE TABLE QTEMP.NODESSHTEST (ID INT, NAME VARCHAR(50))');
-      expect(result3.success).toBe(true);
+      expect(result.data!.length).toBeGreaterThan(0);
+      expect(result.data!.length).toBeLessThanOrEqual(3);
     } finally {
       await job.close();
       ssh.dispose();
@@ -398,154 +536,7 @@ describe('SSH Helper - createNodeSSHExec', () => {
   });
 
   test('should throw error if NodeSSH instance is not connected', () => {
-    // Create disconnected instance
-    ssh = new NodeSSH();
-
-    // Try to create exec function without connecting
-    expect(() => createNodeSSHExec(ssh)).toThrow('NodeSSH instance is not connected');
-
-    ssh.dispose();
-    ssh = null;
-  });
-});
-
-describe('SSH Helpers - Error Handling', () => {
-  if (shouldSkip) {
-    test.skip('SSH tests skipped - set SSH_TEST_HOST and SSH_TEST_USER to enable', () => {});
-    return;
-  }
-
-  test('should handle SSH connection failure gracefully (ssh2)', async () => {
-    const badCreds = {
-      host: 'invalid-host-that-does-not-exist.example.com',
-      port: 22,
-      username: 'invalid',
-      password: 'invalid',
-    };
-
-    const client = new Client();
-    
-    await expect(
-      new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(() => {
-          client.end();
-          reject(new Error('Connection timeout'));
-        }, 5000);
-
-        client.on('ready', () => {
-          clearTimeout(timeout);
-          resolve();
-        });
-        client.on('error', (err) => {
-          clearTimeout(timeout);
-          reject(err);
-        });
-        client.connect(badCreds);
-      })
-    ).rejects.toThrow();
-
-    client.end();
-  });
-
-  test('should handle invalid server path gracefully', async () => {
-    let sshClient: Client | null = null;
-
-    try {
-      sshClient = new Client();
-      await new Promise<void>((resolve, reject) => {
-        sshClient!.on('ready', () => resolve());
-        sshClient!.on('error', (err) => reject(err));
-        sshClient!.connect(SSH_CREDS);
-      });
-
-      const job = SQLJob.withConfig({
-        transport: 'ssh-single',
-        sshSingle: {
-          exec: createSSH2Exec(sshClient),
-          serverPath: '/invalid/path/to/nonexistent.jar',
-          javaPath: SERVER_CONFIG.javaPath,
-          startupTimeout: 5000,
-        },
-      });
-
-      await expect(job.connect()).rejects.toThrow();
-      
-      await job.close();
-    } finally {
-      if (sshClient) {
-        sshClient.end();
-      }
-    }
-  });
-});
-
-describe('SSH Helpers - Integration Tests', () => {
-  if (shouldSkip) {
-    test.skip('SSH tests skipped - set SSH_TEST_HOST and SSH_TEST_USER to enable', () => {});
-    return;
-  }
-
-  test('should work with custom JVM args (ssh2)', async () => {
-    let sshClient: Client | null = null;
-
-    try {
-      sshClient = new Client();
-      await new Promise<void>((resolve, reject) => {
-        sshClient!.on('ready', () => resolve());
-        sshClient!.on('error', (err) => reject(err));
-        sshClient!.connect(SSH_CREDS);
-      });
-
-      const job = SQLJob.withConfig({
-        transport: 'ssh-single',
-        sshSingle: {
-          exec: createSSH2Exec(sshClient),
-          serverPath: SERVER_CONFIG.serverPath,
-          javaPath: SERVER_CONFIG.javaPath,
-          jvmArgs: ['-Xmx512m', '-Dfile.encoding=UTF-8'],
-          startupTimeout: SERVER_CONFIG.startupTimeout,
-        },
-      });
-
-      const result = await job.connect();
-      expect(result.success).toBe(true);
-
-      await job.close();
-      sshClient.end();
-    } finally {
-      if (sshClient) {
-        sshClient.end();
-      }
-    }
-  });
-
-  test('should work with custom working directory (node-ssh)', async () => {
-    let ssh: any = null;
-
-    try {
-      ssh = new NodeSSH();
-      await ssh.connect(SSH_CREDS);
-
-      const job = SQLJob.withConfig({
-        transport: 'ssh-single',
-        sshSingle: {
-          exec: createNodeSSHExec(ssh),
-          serverPath: SERVER_CONFIG.serverPath,
-          javaPath: SERVER_CONFIG.javaPath,
-          cwd: process.env.SSH_TEST_CWD || undefined,
-          startupTimeout: SERVER_CONFIG.startupTimeout,
-        },
-      });
-
-      const result = await job.connect();
-      expect(result.success).toBe(true);
-
-      await job.close();
-      ssh.dispose();
-    } finally {
-      if (ssh) {
-        ssh.dispose();
-      }
-    }
+    const disconnected = new NodeSSH();
+    expect(() => createNodeSSHExec(disconnected)).toThrow('NodeSSH instance is not connected');
   });
 });

--- a/test/sshSingleTransport.test.ts
+++ b/test/sshSingleTransport.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
 import { SSHSingleTransport } from '../src/transports/sshSingleTransport';
-import { ExecChannel, DaemonServer } from '../src/types';
+import { ExecChannel, DaemonServer, ExecFunction, UploadFunction } from '../src/types';
 import { EventEmitter } from 'events';
 import { Readable, Writable } from 'stream';
 
@@ -134,12 +134,12 @@ async function createConnectedTransport(): Promise<{
 describe('SSHSingleTransport', () => {
   let transport: SSHSingleTransport;
   let mockChannel: MockExecChannel;
-  let mockExec: ReturnType<typeof vi.fn>;
+  let mockExec: Mock & ExecFunction;
 
   beforeEach(() => {
     transport = new SSHSingleTransport();
     mockChannel = new MockExecChannel();
-    mockExec = vi.fn().mockResolvedValue(mockChannel);
+    mockExec = vi.fn().mockResolvedValue(mockChannel) as unknown as Mock & ExecFunction;
   });
 
   afterEach(async () => {
@@ -605,3 +605,61 @@ describe('SSHSingleTransport', () => {
 });
 
 
+
+// ---------------------------------------------------------------------------
+// Sub-Task 7 — Integration: SSHSingleTransport private install wiring
+// ---------------------------------------------------------------------------
+
+// Mock ensureServerInstalled so this test only verifies the wiring in
+// SSHSingleTransport.connect() — not installer internals (covered in serverInstaller.test.ts).
+vi.mock('../src/transports/serverInstaller', () => ({
+  ensureServerInstalled: vi.fn().mockResolvedValue('/home/ibmiuser/.mapepire/mapepire-server-mocked.jar'),
+}));
+
+describe('SSHSingleTransport – private install', () => {
+  const MOCKED_REMOTE_JAR = '/home/ibmiuser/.mapepire/mapepire-server-mocked.jar';
+
+  it('calls ensureServerInstalled and uses returned path in launch command', async () => {
+    const serverChannel = new MockExecChannel();
+    const upload = vi.fn().mockResolvedValue(undefined) as unknown as UploadFunction;
+    const exec   = vi.fn().mockResolvedValue(serverChannel) as unknown as ExecFunction;
+
+    const transport = new SSHSingleTransport();
+    const server: DaemonServer = { host: 'ibmi.example.com', user: 'USER', password: 'PASS' };
+
+    simulateHandshake(serverChannel);
+    await transport.connect(server, { exec, upload });
+
+    // Launch command must use the path returned by ensureServerInstalled
+    const remoteCmd = transport.getRemoteCommand();
+    expect(remoteCmd).toContain(MOCKED_REMOTE_JAR);
+    expect(remoteCmd).toContain('--single');
+    expect(transport.isConnected()).toBe(true);
+
+    await transport.close();
+  });
+
+  it('skips ensureServerInstalled when serverPath is explicitly provided', async () => {
+    const serverChannel = new MockExecChannel();
+    const upload = vi.fn().mockResolvedValue(undefined) as unknown as UploadFunction;
+    const exec   = vi.fn().mockResolvedValue(serverChannel) as unknown as ExecFunction;
+
+    const transport = new SSHSingleTransport();
+    const server: DaemonServer = { host: 'ibmi.example.com', user: 'USER', password: 'PASS' };
+
+    simulateHandshake(serverChannel);
+    await transport.connect(server, {
+      exec,
+      upload,
+      serverPath: '/explicit/path/mapepire-server.jar',
+    });
+
+    // Launch command must use the explicit path, not the mocked installer path
+    const remoteCmd = transport.getRemoteCommand();
+    expect(remoteCmd).toContain('/explicit/path/mapepire-server.jar');
+    expect(remoteCmd).not.toContain(MOCKED_REMOTE_JAR);
+    expect(transport.isConnected()).toBe(true);
+
+    await transport.close();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,11 +1,9 @@
 import { defineConfig } from 'vitest/config';
-import { loadEnv } from 'vite';
 
-export default defineConfig(({ mode }) => ({
+export default defineConfig({
   test: {
-    env: loadEnv(mode, process.cwd(), ''),
     // Integration tests that launch the mapepire-server JAR over SSH need
     // more than the default 5000ms — 60s covers cold JVM startup on IBM i.
     testTimeout: 60000,
   },
-}));
+});


### PR DESCRIPTION
Closes #91 

### **What**
Adds SQLJob.ssh2(creds) and SQLJob.nodeSSH(creds) static factories that accept plain SSH credentials and manage the SSH client lifecycle internally. The client is connected on call and torn down automatically when job.close() is called.

### **Before**
```
const client = await connectSSH2({ host, username, password });
const job = SQLJob.withConfig({
  transport: 'ssh-single',
  sshSingle: { ...createSSH2Connection(client) },
});
await job.connect();
// ...
await job.close();
client.end(); // easy to forget
```

### **After**
```
const job = await SQLJob.ssh2({ host, username, password });
await job.connect();
// ...
await job.close(); // SSH client torn down automatically
```

### **Changes**

- SQLJob.ssh2(creds, opts?) — ssh2 credential-first factory
- SQLJob.nodeSSH(creds, opts?) — node-ssh variant
- SSHSingleConfig.teardown — optional callback invoked by the transport on close, used internally by the factories
- src/transports/README.md — updated SSH Single usage docs and helpers table

### **Notes**
_Draft depends on https://github.com/Mapepire-IBMi/mapepire-js/pull/90. Will retarget to main once https://github.com/Mapepire-IBMi/mapepire-js/pull/90 merges._